### PR TITLE
fix: Set Initial bandwidth to 100000 bits

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayerFragment.kt
@@ -26,6 +26,7 @@ import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.drm.DrmSession
 import androidx.media3.exoplayer.drm.MediaDrmCallbackException
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
+import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import com.tpstream.player.databinding.FragmentTpStreamPlayerBinding
 import com.tpstream.player.models.OfflineVideoState
 import com.tpstream.player.views.AdvancedResolutionSelectionSheet
@@ -329,7 +330,11 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     }
 
     private fun initializeExoplayer(): ExoPlayer {
+        val defaultBandwidthMeter = DefaultBandwidthMeter.Builder(requireContext())
+            .setInitialBitrateEstimate(100_000L)
+            .build()
         return ExoPlayer.Builder(requireActivity())
+            .setBandwidthMeter(defaultBandwidthMeter)
             .setTrackSelector(trackSelector)
             .build()
             .also { exoPlayer ->


### PR DESCRIPTION
### Reason for change 
- Player's default bandwidth is 1,000,000 bits.
- This default bandwidth is higher than our minimum resolution bandwidth
- This is one of the reasons for the video loading delay
- Setting the default bandwidth to 100,000 will help to load the video faster than before
- Video will start playing in the low resolution after the change resolution according to internet speed