### PR TITLE
fix: App crash when close the download sheet before loading complete

### DIFF
--- a/player/src/main/java/com/tpstream/player/views/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/views/DownloadResolutionSelectionSheet.kt
@@ -66,6 +66,7 @@ class DownloadResolutionSelectionSheet(
     }
 
     override fun onDownloadRequestHandlerPrepared(isPrepared: Boolean, downloadHelper: DownloadHelper) {
+        if (!this.isVisible) return
         prepareTrackGroup(downloadHelper)
         initializeDownloadResolutionSheet()
         showResolutions(isPrepared)
@@ -87,7 +88,7 @@ class DownloadResolutionSelectionSheet(
     }
 
     private fun showResolutions(isPrepared: Boolean){
-        if (isPrepared && this.isVisible) {
+        if (isPrepared) {
             binding.loadingProgress.visibility = View.GONE
             binding.resolutionLayout.visibility = View.VISIBLE
         }


### PR DESCRIPTION
### Issue
- App crashes when closing the download sheet before loading is completed.
- This issue was created in this commit - #34 
### Reason
- We use callbacks to show the list of resolutions in the download sheet.
- At the time of callback download sheet must be visible. 
### Solution
- We validate download sheet visibility in onDownloadRequestHandlerPrepared()