### PR TITLE
fix: App crash when turning off the internet while downloading video

### DIFF
--- a/player/src/main/java/com/tpstream/player/VideoDownloadService.kt
+++ b/player/src/main/java/com/tpstream/player/VideoDownloadService.kt
@@ -1,7 +1,6 @@
 package com.tpstream.player
 
 import android.app.Notification
-import android.content.Context
 import androidx.media3.common.util.NotificationUtil
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.offline.*


### PR DESCRIPTION
### Issue
- App crash when turning off the internet while video downloading
### Reason
- We did not include PlatformSchedulerService in AndroidManifest.xml
### Solution
- Include PlatformSchedulerService in AndroidManifest.xml 