### PR TITLE
fix: App crash when user provide invalid subdomain

### DIFF
--- a/player/src/main/java/com/tpstream/player/data/source/network/VideoNetworkDataSource.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/network/VideoNetworkDataSource.kt
@@ -1,6 +1,7 @@
 package com.tpstream.player.data.source.network
 
 import com.google.gson.Gson
+import com.google.gson.JsonParseException
 import com.tpstream.player.TPException
 import okhttp3.*
 import java.io.IOException
@@ -47,7 +48,7 @@ internal class VideoNetworkDataSource<T : Any>(val klass: Class<T>) {
                     try {
                         val result = gson.fromJson(response.body?.charStream(), klass)
                         callback.onSuccess(result)
-                    } catch (e: Exception){
+                    } catch (e: JsonParseException){
                         callback.onFailure(TPException.httpError(response))
                     }
                 } else{


### PR DESCRIPTION
### Issue
-  If the user provides an invalid subdomain app will crash.
- Because we parse the response to VideoInfo model class 
- If not able to parse the response it throws an Exception.

### Solution
- Parse the response inside the try-catch block will handle this issue
- If the parsing response is not done its throw TPException