### PR TITLE
fix: Video not remove from DB after deleting

### DIFF
--- a/player/src/main/java/com/tpstream/player/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/VideoRepository.kt
@@ -47,7 +47,7 @@ internal class VideoRepository(context: Context) {
     }
 
     suspend fun delete(video: DatabaseVideo){
-        videoDao.delete(video)
+        videoDao.delete(video.videoId)
     }
 
     fun getVideoByVideoId(videoID:String): DatabaseVideo?{

--- a/player/src/main/java/com/tpstream/player/database/dao/VideoDao.kt
+++ b/player/src/main/java/com/tpstream/player/database/dao/VideoDao.kt
@@ -14,8 +14,8 @@ internal interface VideoDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(video: DatabaseVideo)
 
-    @Delete
-    suspend fun delete(video: DatabaseVideo)
+    @Query("DELETE FROM Video WHERE videoId=:videoID")
+    suspend fun delete(videoID:String)
 
     @Query("SELECT * FROM Video")
     fun getAllVideo():List<DatabaseVideo>?


### PR DESCRIPTION
- #71 This commit has caused degradation in deleting videos from the database.
- Because we use different types of video object
- Now we delete the video by using VideoID