### PR TITLE
fix: Add disable option to seek buttons

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -56,8 +56,10 @@ public interface TpStreamPlayer {
     fun pause()
     fun load(parameters: TpInitParams)
     fun enableOrDisableSeekBar(enable: Boolean, message: String = "Seek option is disabled")
-    fun setShowFastForwardButton(showFastForward: Boolean)
-    fun setShowRewindButton(showRewindButton: Boolean)
+    fun showFastForwardButton()
+    fun hideFastForwardButton()
+    fun showRewindButton()
+    fun hideRewindButton()
 }
 
 internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
@@ -105,12 +107,20 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
         }
     }
 
-    override fun setShowFastForwardButton(showFastForward: Boolean) {
-        tpStreamPlayerImplCallBack?.onFastForwardButtonToggle(showFastForward)
+    override fun showFastForwardButton() {
+        tpStreamPlayerImplCallBack?.onFastForwardButtonToggle(true)
     }
 
-    override fun setShowRewindButton(showRewindButton: Boolean) {
-        tpStreamPlayerImplCallBack?.onRewindButtonToggle(showRewindButton)
+    override fun hideFastForwardButton() {
+        tpStreamPlayerImplCallBack?.onFastForwardButtonToggle(false)
+    }
+
+    override fun showRewindButton() {
+        tpStreamPlayerImplCallBack?.onRewindButtonToggle(true)
+    }
+
+    override fun hideRewindButton() {
+        tpStreamPlayerImplCallBack?.onRewindButtonToggle(false)
     }
 
     private fun playVideoInUIThread(url: String,startPosition: Long = 0) {
@@ -238,6 +248,6 @@ internal interface TpStreamPlayerImplCallBack {
     fun onPlayerPrepare()
     fun onSeekBarDisable(message: String)
     fun onSeekBarEnable()
-    fun onFastForwardButtonToggle(showFastForward: Boolean)
-    fun onRewindButtonToggle(showRewindButton: Boolean)
+    fun onFastForwardButtonToggle(show: Boolean)
+    fun onRewindButtonToggle(show: Boolean)
 }

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -499,15 +499,15 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
             }
         }
 
-        override fun onFastForwardButtonToggle(showFastForward: Boolean) {
+        override fun onFastForwardButtonToggle(show: Boolean) {
             requireActivity().runOnUiThread {
-                viewBinding.videoView.setShowFastForwardButton(showFastForward)
+                viewBinding.videoView.setShowFastForwardButton(show)
             }
         }
 
-        override fun onRewindButtonToggle(showRewindButton: Boolean) {
+        override fun onRewindButtonToggle(show: Boolean) {
             requireActivity().runOnUiThread {
-                viewBinding.videoView.setShowRewindButton(showRewindButton)
+                viewBinding.videoView.setShowRewindButton(show)
             }
         }
 


### PR DESCRIPTION
- In this commit, we introduced a few new functions in the TpStreamPlayers. These methods allow us to manage the visibility of the Seek buttons, with the default value being set to true.