### PR TITLE
fix: Expose method in TpStreamDownloadManager to delete all offline videos

### DIFF
--- a/app/src/main/java/com/tpstream/app/DownloadListActivity.kt
+++ b/app/src/main/java/com/tpstream/app/DownloadListActivity.kt
@@ -32,6 +32,10 @@ class DownloadListActivity : AppCompatActivity() {
         downloadListViewModel.getDownloadData().observe(this) {
             binding.recycleView.adapter = DownloadListAdapter(it!!)
         }
+
+        binding.deleteAllButton.setOnClickListener {
+            downloadListViewModel.deleteAllDownload()
+        }
     }
 
     private fun initializeViewModel(){

--- a/app/src/main/java/com/tpstream/app/DownloadListViewModel.kt
+++ b/app/src/main/java/com/tpstream/app/DownloadListViewModel.kt
@@ -29,4 +29,8 @@ class DownloadListViewModel(context: Context): ViewModel() {
     fun deleteDownload(video: Video) {
         tpStreamDownloadManager.deleteDownload(video)
     }
+
+    fun deleteAllDownload() {
+        tpStreamDownloadManager.deleteAllDownloads()
+    }
 }

--- a/app/src/main/res/layout/activity_download_list.xml
+++ b/app/src/main/res/layout/activity_download_list.xml
@@ -11,8 +11,17 @@
         android:layout_marginTop="8dp"
         android:id="@+id/recycleView"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         app:layoutManager="LinearLayoutManager"
+        tools:itemCount="5"
         tools:listitem="@layout/download_item"/>
+
+    <Button
+        android:id="@+id/delete_all_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:layout_gravity="center_horizontal"
+        android:text="Delete All"/>
 
 </LinearLayout>

--- a/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
@@ -40,6 +40,10 @@ internal class VideoRepository(context: Context) {
         videoDao.delete(video.videoId)
     }
 
+    suspend fun deleteAll(){
+        videoDao.deleteAll()
+    }
+
     fun getAllDownloadsInLiveData():LiveData<List<Video>?>{
         return Transformations.map(videoDao.getAllDownloadInLiveData()) {
             it?.asDomainVideos()

--- a/player/src/main/java/com/tpstream/player/data/source/local/VideoDao.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/local/VideoDao.kt
@@ -30,4 +30,7 @@ internal interface VideoDao {
     @Query("SELECT * FROM Video WHERE downloadState NOT null")
     fun getAllDownloadInLiveData():LiveData<List<LocalVideo>?>
 
+    @Query("DELETE FROM Video")
+    suspend fun deleteAll()
+
 }

--- a/player/src/main/java/com/tpstream/player/offline/DownloadTask.kt
+++ b/player/src/main/java/com/tpstream/player/offline/DownloadTask.kt
@@ -60,6 +60,14 @@ internal class DownloadTask (val context: Context) {
         }
     }
 
+    fun deleteAll() {
+        DownloadService.sendRemoveAllDownloads(
+            context,
+            VideoDownloadService::class.java,
+            false
+        )
+    }
+
     fun isDownloaded(url:String): Boolean {
         val download = downloadIndex.getDownload(url)
         return download != null && download.state == Download.STATE_COMPLETED

--- a/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
+++ b/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
@@ -36,4 +36,12 @@ class TpStreamDownloadManager(val context: Context) {
             videoRepository.delete(video)
         }
     }
+
+    fun deleteAllDownloads() {
+        CoroutineScope(Dispatchers.IO).launch {
+            videoRepository.deleteAll()
+            DownloadTask(context).deleteAll()
+            ImageSaver(context).deleteAll()
+        }
+    }
 }

--- a/player/src/main/java/com/tpstream/player/util/ImageSaver.kt
+++ b/player/src/main/java/com/tpstream/player/util/ImageSaver.kt
@@ -76,4 +76,15 @@ internal class ImageSaver(val context: Context) {
         val file = File(dir, "/thumbnail/$imageFileName.png")
         file.delete()
     }
+
+    fun deleteAll() {
+        val dir = context.filesDir
+        val folder = File(dir, "/thumbnail")
+        if (folder.exists()) {
+            val files = folder.listFiles()
+            files?.forEach { file ->
+                file.delete()
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Previously we didn't provide access to the function for removing all offline videos in TpStreamDownloadManager. However, in this commit, we have introduced a new method called deleteAllDownloads() in TpStreamDownloadManager. This method allows users to delete all offline videos as well as remove all downloaded thumbnails.