### PR TITLE
fix: Video playing for unknown access token

### DIFF
--- a/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
@@ -79,7 +79,6 @@ internal class VideoRepository(context: Context) {
             override fun onSuccess(result: NetworkVideo) {
                 val video = result.asDomainVideo()
                 video.videoId = params.videoId!!
-                storeVideo(video)
                 callback.onSuccess(video)
             }
 
@@ -87,12 +86,6 @@ internal class VideoRepository(context: Context) {
                 callback.onFailure(exception)
             }
         })
-    }
-
-    private fun storeVideo(video: Video){
-        CoroutineScope(Dispatchers.IO).launch {
-            videoDao.insert(video.asLocalVideo())
-        }
     }
 
 }


### PR DESCRIPTION
- Previously we used a repository pattern to retrieve video information. We would fetch the video info and store it in the local database.
- When initializing the player, we would provide the video ID, access token, and org code. Initially, we would check if the video ID is already present locally. If it exists, the player would retrieve the video from the local storage and play it without utilizing the access token for authentication.
- Therefore, in this commit, we modified the behavior to only save video information if the video is downloaded.

