### PR TITLE
fix: Add ExoPlayer-like Builder class inside TpStreamPlayer

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -57,6 +57,12 @@ public interface TpStreamPlayer {
     fun play()
     fun pause()
     fun load(parameters: TpInitParams)
+
+    class Builder(private val context: Context) {
+        fun build(): TpStreamPlayer {
+            return TpStreamPlayerImpl(context)
+        }
+    }
 }
 
 internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {


### PR DESCRIPTION
- In this commit, a Builder class has been added to the TpStreamPlayer interface. This enables users to create instances of TpStreamPlayerImpl, and use it with TPStreamPlayerView and replicating ExoPlayer-like functionality.