### PR TITLE
fix: Build unified SDK for Testpress and Streams

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -19,6 +19,7 @@ class PlayerActivity : AppCompatActivity() {
     private lateinit var accessToken :String
     private lateinit var videoId :String
     private lateinit var orgCode :String
+    private lateinit var provider: TPStreamsSDK.Provider
     private var parameters : TpInitParams? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -26,6 +27,7 @@ class PlayerActivity : AppCompatActivity() {
         setContentView(R.layout.activity_player)
         parameters = intent.getParcelableExtra(TP_OFFLINE_PARAMS)
         selectVideoParams(intent.getStringExtra("VideoParameter"))
+        TPStreamsSDK.initialize(provider, orgCode)
         playerFragment =
             supportFragmentManager.findFragmentById(R.id.tpstream_player_fragment) as TpStreamPlayerFragment
         playerFragment.enableAutoFullScreenOnRotate()
@@ -55,7 +57,6 @@ class PlayerActivity : AppCompatActivity() {
             parameters = TpInitParams.Builder()
                 .setVideoId(videoId)
                 .setAccessToken(accessToken)
-                .setOrgCode(orgCode)
                 .setAutoPlay(true)
                 .enableDownloadSupport(true)
                 .build()
@@ -69,26 +70,31 @@ class PlayerActivity : AppCompatActivity() {
                 accessToken = "c381512b-7337-4d8e-a8cf-880f4f08fd08"
                 videoId = "C3XLe1CCcOq"
                 orgCode = "demoveranda"
+                provider = TPStreamsSDK.Provider.TestPress
             }
             "TP_AES_Encrypt" -> {
                 accessToken = "143a0c71-567e-4ecd-b22d-06177228c25b"
                 videoId = "o7pOsacWaJt"
                 orgCode = "demoveranda"
+                provider = TPStreamsSDK.Provider.TestPress
             }
             "TP_NON_DRM" -> {
                 accessToken = "70f61402-3724-4ed8-99de-5473b2310efe"
                 videoId = "qJQlWGLJvNv"
                 orgCode = "demoveranda"
+                provider = TPStreamsSDK.Provider.TestPress
             }
             "TPS_DRM" -> {
                 accessToken = "565a5b8c-310a-444b-956e-bbd6c7c74d7b"
                 videoId = "d19729f0-8823-4805-9034-2a7ea9429195"
                 orgCode = "edee9b"
+                provider = TPStreamsSDK.Provider.TPStreams
             }
             "TPS_NON_DRM" -> {
                 accessToken = "4b11bf9e-d6b7-4b1f-80b8-19d92b26e966"
                 videoId = "73633fa3-61c6-443c-b625-ac4e85b28cfc"
                 orgCode = "edee9b"
+                provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}
         }

--- a/player/build.gradle
+++ b/player/build.gradle
@@ -1,14 +1,9 @@
-import groovy.json.JsonSlurper
-
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
     id 'kotlin-parcelize'
     id 'kotlin-kapt'
 }
-
-def jsonFile = file('src/main/assets/config.json')
-def json = new JsonSlurper().parseText(jsonFile.text)
 
 android {
     namespace 'com.tpstream.player'
@@ -25,14 +20,6 @@ android {
                 arguments += ["room.schemaLocation":
                                       "$projectDir/schemas".toString()]
             }
-        }
-
-        if (json.provider == "testpress") {
-            buildConfigField "String", "VIDEO_URL", "\"" +json.testpress_base_url+json.testpress_video_path + "\""
-            buildConfigField "String", "DRM_LICENSE_URL", "\"" + json.testpress_base_url+json.testpress_drm_license_path + "\""
-        } else {
-            buildConfigField "String", "VIDEO_URL", "\"" + json.tpStreams_base_url+json.tpStreams_video_path + "\""
-            buildConfigField "String", "DRM_LICENSE_URL", "\"" + json.tpStreams_base_url+json.tpStreams_drm_license_path + "\""
         }
     }
 

--- a/player/src/main/assets/config.json
+++ b/player/src/main/assets/config.json
@@ -1,9 +1,0 @@
-{
-  "provider" : "tpstreams",
-  "testpress_base_url" : "https://%s.testpress.in",
-  "tpStreams_base_url" : "https://app.tpstreams.com",
-  "testpress_video_path" : "/api/v2.5/video_info/%s/?access_token=%s",
-  "tpStreams_video_path" : "/api/v1/%s/assets/%s/?access_token=%s",
-  "testpress_drm_license_path" : "/api/v2.5/drm_license_key/%s/?access_token=%s",
-  "tpStreams_drm_license_path" : "/api/v1/%s/assets/%s/drm_license/?access_token=%s"
-}

--- a/player/src/main/java/com/tpstream/player/EncryptionKeyDownloader.kt
+++ b/player/src/main/java/com/tpstream/player/EncryptionKeyDownloader.kt
@@ -44,7 +44,7 @@ internal class EncryptionKeyDownloader {
 
      fun getEncryptionKey(params: TpInitParams): String {
         val request = Request.Builder()
-            .url("https://${params.orgCode}.testpress.in/api/v2.5/encryption_key/${params.videoId}/?access_token=${params.accessToken}")
+            .url("https://${TPStreamsSDK.orgCode}.testpress.in/api/v2.5/encryption_key/${params.videoId}/?access_token=${params.accessToken}")
             .build()
         val response = OkHttpClient().newCall(request).execute()
         return response.body?.byteStream()?.readBytes()?.contentToString() ?: ""

--- a/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
@@ -1,0 +1,43 @@
+package com.tpstream.player
+
+object TPStreamsSDK {
+    private var provider: Provider = Provider.TPStreams
+    private var _orgCode: String? = null
+    val orgCode: String
+        get() {
+            if (_orgCode == null) {
+                throw IllegalStateException("TPStreamsSDK is not initialized. You must call initialize first.")
+            }
+            return _orgCode!!
+        }
+
+    fun initialize(provider: Provider = Provider.TPStreams, orgCode: String) {
+        if (orgCode.isEmpty()) {
+            throw IllegalArgumentException("orgCode cannot be empty.")
+        }
+
+        this._orgCode = orgCode
+        this.provider = provider
+    }
+
+    fun constructVideoInfoUrl(contentId: String?, accessToken: String?): String {
+        val url = when (provider) {
+            Provider.TestPress -> "https://%s.testpress.in/api/v2.5/video_info/%s/?access_token=%s"
+            Provider.TPStreams -> "https://app.tpstreams.com/api/v1/%s/assets/%s/?access_token=%s"
+        }
+        return url.format(orgCode, contentId, accessToken)
+    }
+
+    fun constructDRMLicenseUrl(contentId: String?, accessToken: String?): String {
+        val url = when (provider) {
+            Provider.TestPress -> "https://%s.testpress.in/api/v2.5/drm_license_key/%s/?access_token=%s"
+            Provider.TPStreams -> "https://app.tpstreams.com/api/v1/%s/assets/%s/drm_license/?access_token=%s"
+        }
+        return url.format(orgCode, contentId, accessToken)
+    }
+
+    enum class Provider {
+        TestPress,
+        TPStreams
+    }
+}

--- a/player/src/main/java/com/tpstream/player/TpInitParams.kt
+++ b/player/src/main/java/com/tpstream/player/TpInitParams.kt
@@ -8,7 +8,6 @@ data class TpInitParams (
     var autoPlay: Boolean? = null,
     var accessToken: String? = null,
     var videoId: String? = null,
-    var orgCode: String,
     var isDownloadEnabled: Boolean = false,
     var startAt: Long = 0L
 ): Parcelable {
@@ -17,7 +16,6 @@ data class TpInitParams (
         private var autoPlay: Boolean? = null
         private var accessToken: String? = null
         private var videoId: String? = null
-        private var orgCode: String? = null
         private var isDownloadEnabled: Boolean = false
         private var startAt: Long = 0L
 
@@ -25,19 +23,13 @@ data class TpInitParams (
         fun startAt(timeInSeconds: Long) = apply { this.startAt = timeInSeconds }
         fun setAccessToken(accessToken: String) = apply { this.accessToken = accessToken }
         fun setVideoId(videoId: String) = apply { this.videoId = videoId }
-        fun setOrgCode(subdomain: String) = apply { this.orgCode = subdomain }
         fun enableDownloadSupport(isDownloadEnabled: Boolean) = apply { this.isDownloadEnabled = isDownloadEnabled }
 
         fun build(): TpInitParams {
-            if (orgCode == null) {
-                throw Exception("orgCode should be provided")
-            }
-
             return TpInitParams(
                 autoPlay,
                 accessToken,
                 videoId,
-                orgCode!!,
                 isDownloadEnabled,
                 startAt
             )
@@ -48,14 +40,12 @@ data class TpInitParams (
         get() = startAt * 1000L
 
     fun createParamsWithOtp(
-        orgCode: String,
         accessToken: String?,
         videoId: String?
     ): TpInitParams {
         return TpInitParams(
             accessToken = accessToken,
             videoId = videoId,
-            orgCode = orgCode
         )
     }
 
@@ -63,7 +53,6 @@ data class TpInitParams (
         fun createOfflineParams(videoId: String):TpInitParams{
             return TpInitParams(
                 videoId = videoId,
-                orgCode = "",
                 isDownloadEnabled = true,
                 autoPlay = true
             )

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -138,7 +138,7 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
     }
 
     private fun buildMediaItem(url: String): MediaItem {
-        val drmLicenseURL = BuildConfig.DRM_LICENSE_URL.format(params.orgCode,params.videoId,params.accessToken)
+        val drmLicenseURL = TPStreamsSDK.constructDRMLicenseUrl(params.videoId, params.accessToken)
         return MediaItem.Builder()
             .setUri(url)
             .setDrmConfiguration(

--- a/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Transformations
 import com.tpstream.player.BuildConfig
 import com.tpstream.player.TPException
+import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpInitParams
 import com.tpstream.player.data.source.local.TPStreamsDatabase
 import com.tpstream.player.data.source.network.NetworkVideo
@@ -74,7 +75,7 @@ internal class VideoRepository(context: Context) {
         params: TpInitParams,
         callback : VideoNetworkDataSource.TPResponse<Video>
     ) {
-        val url =BuildConfig.VIDEO_URL.format(params.orgCode,params.videoId,params.accessToken)
+        val url = TPStreamsSDK.constructVideoInfoUrl(params.videoId, params.accessToken)
         VideoNetworkDataSource<NetworkVideo>().get(url, object : VideoNetworkDataSource.TPResponse<NetworkVideo> {
             override fun onSuccess(result: NetworkVideo) {
                 val video = result.asDomainVideo()

--- a/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
+++ b/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
@@ -13,6 +13,7 @@ import androidx.media3.exoplayer.offline.Download
 import androidx.media3.exoplayer.offline.DownloadHelper
 import androidx.media3.exoplayer.offline.DownloadRequest
 import com.tpstream.player.BuildConfig
+import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpInitParams
 import com.tpstream.player.offline.VideoDownload.getDownloadRequest
 import kotlinx.coroutines.CoroutineScope
@@ -46,7 +47,7 @@ internal object OfflineDRMLicenseHelper {
         val dashManifest = DashUtil.loadManifest(dataSource, Uri.parse(url))
         val drmInitData =
             DashUtil.loadFormatWithDrmInitData(dataSource, dashManifest.getPeriod(0))
-        val drmLicenseURL = "${BuildConfig.DRM_LICENSE_URL.format(tpInitParams.orgCode,tpInitParams.videoId,tpInitParams.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
+        val drmLicenseURL = "${TPStreamsSDK.constructDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
         return OfflineLicenseHelper.newWidevineInstance(
             drmLicenseURL,
             VideoDownloadManager.invoke(context).getHttpDataSourceFactory(),
@@ -108,7 +109,7 @@ internal object OfflineDRMLicenseHelper {
         downloadHelper: DownloadHelper,
         callback: DRMLicenseFetchCallback
     ) {
-        val drmLicenseURL = "${BuildConfig.DRM_LICENSE_URL.format(tpInitParams.orgCode,tpInitParams.videoId,tpInitParams.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
+        val drmLicenseURL = "${TPStreamsSDK.constructDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
         val offlineLicenseHelper = OfflineLicenseHelper.newWidevineInstance(
             drmLicenseURL,
             VideoDownloadManager.invoke(context).getHttpDataSourceFactory(),

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -11,6 +11,7 @@ import androidx.media3.exoplayer.offline.DownloadHelper
 import androidx.media3.exoplayer.offline.DownloadRequest
 import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import com.tpstream.player.BuildConfig
+import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpStreamPlayerImpl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +32,7 @@ internal class VideoDownloadRequestCreationHandler(
     init {
         val url = player.video?.url!!
         trackSelectionParameters = DownloadHelper.getDefaultTrackSelectorParameters(context)
-        val drmLicenseURL = "${BuildConfig.DRM_LICENSE_URL.format(player.params.orgCode,player.params.videoId,player.params.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
+        val drmLicenseURL = "${TPStreamsSDK.constructDRMLicenseUrl(player.params.videoId, player.params.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
         mediaItem = MediaItem.Builder()
             .setUri(url)
             .setDrmConfiguration(

--- a/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
+++ b/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
@@ -2,6 +2,7 @@ package com.tpstream.player.util
 
 import androidx.media3.common.PlaybackException
 import com.tpstream.player.TPException
+import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpInitParams
 import io.sentry.Sentry
 
@@ -12,7 +13,7 @@ internal object SentryLogger {
                 " Message: ${exception.response?.message}" +
                 " Video ID: ${params?.videoId}" +
                 " AccessToken: ${params?.accessToken}" +
-                " Org Code: ${params?.orgCode}")
+                " Org Code: ${TPStreamsSDK.orgCode}")
     }
 
     fun logPlaybackException(error: PlaybackException,params: TpInitParams?){
@@ -22,6 +23,6 @@ internal object SentryLogger {
                 " Message: ${error.message}" +
                 " Video ID: ${params?.videoId}" +
                 " AccessToken: ${params?.accessToken}" +
-                " Org Code: ${params?.orgCode}")
+                " Org Code: ${TPStreamsSDK.orgCode}")
     }
 }

--- a/player/src/main/java/com/tpstream/player/util/VideoPlayerInterceptor.kt
+++ b/player/src/main/java/com/tpstream/player/util/VideoPlayerInterceptor.kt
@@ -2,6 +2,7 @@ package com.tpstream.player.util
 
 import android.content.Context
 import com.tpstream.player.EncryptionKeyRepository
+import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpInitParams
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
@@ -24,7 +25,7 @@ internal class VideoPlayerInterceptor(private val context: Context, private val 
                 return response
             } else {
                 request = request.newBuilder()
-                    .url("https://${params?.orgCode}.testpress.in/api/v2.5/encryption_key/${params?.videoId}/?access_token=${params?.accessToken}")
+                    .url("https://${TPStreamsSDK.orgCode}.testpress.in/api/v2.5/encryption_key/${params?.videoId}/?access_token=${params?.accessToken}")
                     .build()
             }
         }


### PR DESCRIPTION
- Added support for building a unified SDK package for Testpress and TPStreams. 
- Introduced an SDK Initializer class that allows specifying the provider they are using and constructs API URLs accordingly.