### PR TITLE
fix: Not able to switch from landscape to portrait when auto rotate option is on

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -140,7 +140,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     }
 
     fun exitFullScreen() {
-        requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        requireActivity().requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         (tpStreamPlayerView.parent as ViewGroup).removeView(tpStreamPlayerView)
         viewBinding.mainFrameLayout.addView(tpStreamPlayerView)
         tpStreamPlayerView.findViewById<ImageButton>(R.id.fullscreen).setImageDrawable(

--- a/player/src/main/java/com/tpstream/player/util/OrientationListener.kt
+++ b/player/src/main/java/com/tpstream/player/util/OrientationListener.kt
@@ -1,6 +1,7 @@
 package com.tpstream.player.util
 
 import android.content.Context
+import android.content.pm.ActivityInfo
 import android.provider.Settings
 import android.view.OrientationEventListener
 
@@ -26,6 +27,9 @@ internal class OrientationListener(val context: Context): OrientationEventListen
 
     private fun isOrientationChanged(orientation: Int): Boolean {
         var isLandscapeCurrently = false
+        if (isLandscape && orientation == ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED) {
+            isLandscapeCurrently = true
+        }
         if (orientation in 45..135 || orientation in 225..300) {
             isLandscapeCurrently = true
         }


### PR DESCRIPTION
- Previously while exiting the fullscreen mode we set the screen orientation to `SCREEN_ORIENTATION_UNSPECIFIED`.
- In this commit, we changed to `SCREEN_ORIENTATION_PORTRAIT` Whenever the user exits the fullscreen mode we set the screen orientation to portrait and we do not change the screen orientation when the device is flat