### PR TITLE
enhancement: Expose API for set maximum video resolution in player

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -27,6 +27,7 @@ public interface TpStreamPlayer {
     fun seekTo(seconds: Long)
     fun getVideoFormat(): Format?
     fun getCurrentTrackGroups(): ImmutableList<TracksGroup>
+    fun setMaxVideoSize(maxVideoWidth: Int, maxVideoHeight: Int)
     fun getDuration(): Long
     fun setListener(listener: TPStreamPlayerListener?)
     fun play()
@@ -183,6 +184,13 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
     override fun getVideoFormat(): Format? = exoPlayer.videoFormat
 
     override fun getCurrentTrackGroups(): ImmutableList<TracksGroup> = exoPlayer.currentTracks.groups
+
+    override fun setMaxVideoSize(maxVideoWidth: Int, maxVideoHeight: Int) {
+        val trackSelectionParameters = TrackSelectionParametersBuilder(context)
+            .setMaxVideoSize(maxVideoWidth,maxVideoHeight)
+            .build()
+        setTrackSelectionParameters(trackSelectionParameters)
+    }
 
     override fun getDuration(): Long = exoPlayer.duration
 


### PR DESCRIPTION
- In this commit, we added the setMaxVideoSize() method to TpStreamPlayer.
- This method is used to limit the maximum video resolution size for the player.