### PR TITLE
fix: UI Conflicts for playback speed button

### DIFF
--- a/player/src/main/player-mapping-files/layout/exo_player2_control_view.xml
+++ b/player/src/main/player-mapping-files/layout/exo_player2_control_view.xml
@@ -74,17 +74,13 @@
 
             <Button
                 android:id="@id/exo_playback_speed"
+                style="@style/PlayBackSpeedButtonTheme"
                 android:layout_width="36dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginRight="12dp"
-                android:backgroundTint="#ffffff"
-                android:gravity="center"
-                android:padding="0dp"
-                android:text="1x"
-                android:textAllCaps="false"
-                android:textColor="#000000"
-                android:textSize="12sp" />
+                android:layout_height="18dp"
+                android:layout_marginEnd="12dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:text="1x" />
 
             <ImageButton android:id="@id/exo_overflow_show"
                 style="@style/ExoStyledControls.Button.Bottom.OverflowShow"/>

--- a/player/src/main/player-mapping-files/layout/media3_player_control_view.xml
+++ b/player/src/main/player-mapping-files/layout/media3_player_control_view.xml
@@ -74,17 +74,13 @@
 
             <Button
                 android:id="@id/exo_playback_speed"
+                style="@style/PlayBackSpeedButtonTheme"
                 android:layout_width="36dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginRight="12dp"
-                android:backgroundTint="#ffffff"
-                android:gravity="center"
-                android:padding="0dp"
-                android:text="1x"
-                android:textAllCaps="false"
-                android:textColor="#000000"
-                android:textSize="12sp" />
+                android:layout_height="18dp"
+                android:layout_marginEnd="12dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:text="1x" />
 
             <ImageButton android:id="@id/exo_overflow_show"
                 style="@style/ExoStyledControls.Button.Bottom.OverflowShow"/>

--- a/player/src/main/res/drawable/tp_playback_speed_button.xml
+++ b/player/src/main/res/drawable/tp_playback_speed_button.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/tp_white"/>
+    <corners android:radius="2dp"/>
+</shape>

--- a/player/src/main/res/layout/exo_player_control_view.xml
+++ b/player/src/main/res/layout/exo_player_control_view.xml
@@ -74,17 +74,13 @@
 
             <Button
                 android:id="@id/exo_playback_speed"
+                style="@style/PlayBackSpeedButtonTheme"
                 android:layout_width="36dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center_vertical"
-                android:layout_marginRight="12dp"
-                android:backgroundTint="#ffffff"
-                android:gravity="center"
-                android:padding="0dp"
-                android:text="1x"
-                android:textAllCaps="false"
-                android:textColor="#000000"
-                android:textSize="12sp" />
+                android:layout_height="18dp"
+                android:layout_marginEnd="12dp"
+                android:insetTop="0dp"
+                android:insetBottom="0dp"
+                android:text="1x" />
 
             <ImageButton android:id="@id/exo_overflow_show"
                 style="@style/ExoStyledControls.Button.Bottom.OverflowShow"/>

--- a/player/src/main/res/values/styles.xml
+++ b/player/src/main/res/values/styles.xml
@@ -6,4 +6,15 @@
         <item name="colorAccent">@color/tp_download_button_blue</item>
     </style>
 
+    <style name="PlayBackSpeedButtonTheme" parent="Theme.AppCompat.Light">
+        <item name="textAllCaps">false</item>
+        <item name="android:textColor">#000000</item>
+        <item name="android:textSize">12sp</item>
+        <item name="android:background">@drawable/tp_playback_speed_button</item>
+        <item name="backgroundTint">@color/tp_white</item>
+        <item name="android:gravity">center</item>
+        <item name="android:layout_gravity">center_vertical</item>
+        <item name="android:padding">0dp</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
- The playback speed button UI is overridden by various versions of the material library.
- In this commit, we introduced a distinct style for the playback speed button to prevent UI conflicts.