### PR TITLE
fix: App crash after the video buffer end when device has no Internet Connection

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -255,11 +255,11 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         override fun onIsLoadingChanged(isLoading: Boolean) {
             super.onIsLoadingChanged(isLoading)
             if (!isLoading && player.getPlaybackState() == TpStreamPlayer.PLAYBACK_STATE.STATE_READY) {
-                adjustResolutionIfExceedsMax()
+                restrictVideoToMaximumResolution()
             }
         }
 
-        private fun adjustResolutionIfExceedsMax() {
+        private fun restrictVideoToMaximumResolution() {
             val maxResolution = player.getMaxResolution()
             val videoHeight = player.getVideoFormat()?.height
             if (maxResolution != null && videoHeight != null && videoHeight > maxResolution) {


### PR DESCRIPTION
- The `onIsLoadingChanged()` method was encountering a crash due to accessing the current video resolution height when the player was not actively playing, resulting in a null value. This issue arose from the lack of proper null handling in such scenarios.
- This commit addresses the problem by appropriately handling the max resolution during active player sessions and implementing null object handling for video height.