### PR TITLE
fix: Resolve WindowLeaked exception in `TpStreamPlayerFragment`

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -94,6 +94,11 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        // Ensure that the full-screen dialog is dismissed when the Activity is destroyed
+        // to prevent a WindowLeaked exception. This is necessary to handle scenarios
+        // where the dialog is still visible when the Activity is no longer in the foreground.
+        if (fullScreenDialog.isShowing)
+            fullScreenDialog.onBackPressed()
         _viewBinding = null
     }
 


### PR DESCRIPTION
- In this commit, We ensure proper dismissal of full-screen dialog to prevent WindowLeaked exception when the `TpStreamPlayerFragment` is destroyed