### PR TITLE
fix: Error message displayed when player is loading

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -227,7 +227,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         private val TAG = "PlayerListener"
 
         override fun onPlaybackStateChanged(playbackState: Int) {
-            if (playbackState == ExoPlayer.STATE_READY) {
+            if (playbackState == ExoPlayer.STATE_READY || playbackState == ExoPlayer.STATE_BUFFERING) {
                 viewBinding.errorMessage.visibility = View.GONE
                 tpStreamPlayerView.hideReplayButton()
                 tpStreamPlayerView.showPlayButton()


### PR DESCRIPTION
- We hide the error message when the player state is ready, but during buffering, the error message is displayed.
- In this commit, we hide the error message when the player state is buffering.