### PR TITLE
fix Fragment Attachment Check in `onPlaybackError()`

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -322,6 +322,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private val tpStreamPlayerImplCallBack = object :TpStreamPlayerImplCallBack{
 
         override fun onPlaybackError(parameters: TpInitParams, exception: TPException) {
+            if (!isAdded) return
             requireActivity().runOnUiThread{
                 val errorPlayerId = SentryLogger.generatePlayerIdString()
                 showErrorMessage(exception.getErrorMessage(errorPlayerId))


### PR DESCRIPTION
- Previously in the onPlaybackError method a fragment attachment check was missing.
- In this commit, We ensure that the method is only executed when the fragment is attached to an activity, preventing a possible IllegalStateException.





