### PR TITLE
fix: Add consumer rules to avoid removal of essential libraries

### DIFF
--- a/player/consumer-rules.pro
+++ b/player/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class com.tpstream.player.** { *; }


### PR DESCRIPTION
- Within the Flutter player SDK, we utilize the Android native player SDK, where ProGuard is consistently enabled in the Flutter environment. Unfortunately, there is no provision to include ProGuard rules directly in the Flutter project.
- In order to prevent the inadvertent removal of essential libraries, we have incorporated ProGuard rules in the consumer rules section of our Android player SDK.





