### PR TITLE
fix: Resolution not listing in advance resolution sheet

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/AdvancedResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/AdvancedResolutionSelectionSheet.kt
@@ -75,39 +75,28 @@ internal class AdvancedResolutionSelectionSheet(
     }
 
     private fun getTrackInfos(): ArrayList<TrackInfo> {
-        val trackInfos = arrayListOf<TrackInfo>()
         if (trackGroups.none { it.mediaTrackGroup.type == C.TRACK_TYPE_VIDEO }) {
-            return trackInfos
+            return arrayListOf()
         }
 
         val trackGroup = trackGroups.first { it.mediaTrackGroup.type == C.TRACK_TYPE_VIDEO }
-        if (player.getMaxResolution() == null) {
-            addAllTrackInfo(trackGroup, trackInfos)
+        return if (player.getMaxResolution() == null) {
+            addAllTrackInfo(trackGroup)
         } else {
-            addTrackInfoBelowMaxResolution(trackGroup, trackInfos)
-        }
-        return trackInfos
-    }
-
-    private fun addAllTrackInfo(
-        trackGroup: TracksGroup,
-        trackInfos: ArrayList<TrackInfo>
-    ) {
-        for (trackIndex in 0 until trackGroup.length) {
-            trackInfos.add(TrackInfo(trackGroup, trackIndex))
+            addTrackInfoBelowMaxResolution(trackGroup)
         }
     }
 
-    private fun addTrackInfoBelowMaxResolution(
-        trackGroup: TracksGroup,
-        trackInfos: ArrayList<TrackInfo>
-    ) {
-        for (trackIndex in 0 until trackGroup.length) {
-            val trackFormat = trackGroup.mediaTrackGroup.getFormat(trackIndex)
-            if (player.getMaxResolution()!! >= trackFormat.height) {
-                trackInfos.add(TrackInfo(trackGroup, trackIndex))
-            }
-        }
+    private fun addAllTrackInfo(trackGroup: TracksGroup): ArrayList<TrackInfo> {
+        return (0 until trackGroup.length).mapTo(arrayListOf()) { TrackInfo(trackGroup, it) }
+    }
+
+    private fun addTrackInfoBelowMaxResolution(trackGroup: TracksGroup): ArrayList<TrackInfo> {
+        val maxResolution = player.getMaxResolution()!!
+
+        return (0 until trackGroup.length)
+            .filter { maxResolution >= trackGroup.mediaTrackGroup.getFormat(it).height }
+            .mapTo(arrayListOf()) { TrackInfo(trackGroup, it) }
     }
 
     private fun configureBottomSheetBehaviour() {


### PR DESCRIPTION
- In commit 7f892cc, we introduced functionality to limit the maximum resolution for the player.
- Previously we would provide an empty sheet if the maximum resolution value was not specified.
- In this commit, we have implemented validation for both scenarios: if the maximum resolution is null, we include all tracks; otherwise, we include only tracks below the maximum resolution.





