### PR TITLE
refactor: construct Offline DRM License URL in `TPStreamsSDK`

### DIFF
--- a/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
@@ -36,6 +36,10 @@ object TPStreamsSDK {
         return url.format(orgCode, contentId, accessToken)
     }
 
+    internal fun constructOfflineDRMLicenseUrl(contentId: String?, accessToken: String?): String {
+        return "${constructDRMLicenseUrl(contentId, accessToken)}&drm_type=widevine&download=true"
+    }
+
     enum class Provider {
         TestPress,
         TPStreams

--- a/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
+++ b/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
@@ -12,8 +12,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-internal const val OFFLINE_DRM_LICENSE_PARAMS = "&drm_type=widevine&download=true"
-
 internal object OfflineDRMLicenseHelper {
 
     fun renewLicense(
@@ -39,7 +37,7 @@ internal object OfflineDRMLicenseHelper {
         val dashManifest = DashUtil.loadManifest(dataSource, Uri.parse(url))
         val drmInitData =
             DashUtil.loadFormatWithDrmInitData(dataSource, dashManifest.getPeriod(0))
-        val drmLicenseURL = "${TPStreamsSDK.constructDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
+        val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken)
         return OfflineLicenseHelper.newWidevineInstance(
             drmLicenseURL,
             VideoDownloadManager.invoke(context).getHttpDataSourceFactory(),
@@ -101,7 +99,7 @@ internal object OfflineDRMLicenseHelper {
         downloadHelper: DownloadHelper,
         callback: DRMLicenseFetchCallback
     ) {
-        val drmLicenseURL = "${TPStreamsSDK.constructDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
+        val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken)
         val offlineLicenseHelper = OfflineLicenseHelper.newWidevineInstance(
             drmLicenseURL,
             VideoDownloadManager.invoke(context).getHttpDataSourceFactory(),

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -25,7 +25,7 @@ internal class VideoDownloadRequestCreationHandler(
     init {
         val url = player.video?.url!!
         trackSelectionParameters = DownloadHelper.getDefaultTrackSelectorParameters(context)
-        val drmLicenseURL = "${TPStreamsSDK.constructDRMLicenseUrl(player.params.videoId, player.params.accessToken)}$OFFLINE_DRM_LICENSE_PARAMS"
+        val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(player.params.videoId, player.params.accessToken)
         mediaItem = MediaItemBuilder()
             .setUri(url)
             .setDrmConfiguration(


### PR DESCRIPTION
- Precisely we construct Offline DRM License URL in `OfflineDRMLicenseHelper`, `VideoDownloadRequestCreationHandler`
- In this commit, we extract to `TPStreamsSDK`