### PR TITLE
refactor: Rename network classes

### DIFF
--- a/player/src/main/java/com/tpstream/player/data/VideoModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoModelMapping.kt
@@ -1,7 +1,7 @@
 package com.tpstream.player.data
 
 import com.tpstream.player.data.source.local.LocalVideo
-import com.tpstream.player.data.source.network.NetworkVideo
+import com.tpstream.player.data.source.network.NetworkAsset
 
 // LocalVideo to Video
 internal fun LocalVideo.asDomainVideo(): Video {
@@ -26,12 +26,12 @@ internal fun LocalVideo.asDomainVideo(): Video {
 internal fun List<LocalVideo>.asDomainVideos() = map(LocalVideo::asDomainVideo)
 
 //NetworkVideo to Video
-internal fun NetworkVideo.asDomainVideo(): Video {
-    val thumbnailUrl = if (networkVideoContent != null) networkVideoContent.preview_thumbnail_url
+internal fun NetworkAsset.asDomainVideo(): Video {
+    val thumbnailUrl = if (networkVideo != null) networkVideo.preview_thumbnail_url
         ?: "" else thumbnail ?: ""
-    val url = if (networkVideoContent != null) {
-        if (networkVideoContent.enable_drm == true) networkVideoContent.dash_url
-            ?: "" else networkVideoContent.playback_url ?: ""
+    val url = if (networkVideo != null) {
+        if (networkVideo.enable_drm == true) networkVideo.dash_url
+            ?: "" else networkVideo.playback_url ?: ""
     } else {
         dashUrl ?: url ?: ""
     }

--- a/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
@@ -7,7 +7,7 @@ import com.tpstream.player.TPException
 import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpInitParams
 import com.tpstream.player.data.source.local.TPStreamsDatabase
-import com.tpstream.player.data.source.network.NetworkVideo
+import com.tpstream.player.data.source.network.NetworkAsset
 import com.tpstream.player.data.source.network.VideoNetworkDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
@@ -73,8 +73,8 @@ internal class VideoRepository(context: Context) {
         callback : VideoNetworkDataSource.TPResponse<Video>
     ) {
         val url = TPStreamsSDK.constructVideoInfoUrl(params.videoId, params.accessToken)
-        VideoNetworkDataSource<NetworkVideo>().get(url, object : VideoNetworkDataSource.TPResponse<NetworkVideo> {
-            override fun onSuccess(result: NetworkVideo) {
+        VideoNetworkDataSource<NetworkAsset>().get(url, object : VideoNetworkDataSource.TPResponse<NetworkAsset> {
+            override fun onSuccess(result: NetworkAsset) {
                 val video = result.asDomainVideo()
                 video.videoId = params.videoId!!
                 callback.onSuccess(video)

--- a/player/src/main/java/com/tpstream/player/data/source/network/NetworkAsset.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/network/NetworkAsset.kt
@@ -2,7 +2,7 @@ package com.tpstream.player.data.source.network
 
 import com.google.gson.annotations.SerializedName
 
-internal data class NetworkVideo(
+internal data class NetworkAsset(
     val title: String?,
     val thumbnail: String?,
 
@@ -27,10 +27,10 @@ internal data class NetworkVideo(
     val bytes: Long?,
     val type: String?,
     @SerializedName("video")
-    val networkVideoContent: NetworkVideoContent?
+    val networkVideo: NetworkVideo?
 ) {
 
-    inner class NetworkVideoContent(
+    inner class NetworkVideo(
         val progress: Int?,
         val thumbnails: Array<String>?,
         val status: String?,

--- a/player/src/test/java/com/tpstream/player/NetworkTest.kt
+++ b/player/src/test/java/com/tpstream/player/NetworkTest.kt
@@ -1,7 +1,7 @@
 package com.tpstream.player
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.tpstream.player.data.source.network.NetworkVideo
+import com.tpstream.player.data.source.network.NetworkAsset
 import com.tpstream.player.data.source.network.VideoNetworkDataSource
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
@@ -19,18 +19,18 @@ class NetworkTest {
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     private lateinit var mockWebServer: MockWebServer
-    private val network: VideoNetworkDataSource<NetworkVideo> = VideoNetworkDataSource(NetworkVideo::class.java)
+    private val network: VideoNetworkDataSource<NetworkAsset> = VideoNetworkDataSource(NetworkAsset::class.java)
 
-    private lateinit var callbackResponse: VideoNetworkDataSource.TPResponse<NetworkVideo>
-    private var callbackResult: NetworkVideo? = null
+    private lateinit var callbackResponse: VideoNetworkDataSource.TPResponse<NetworkAsset>
+    private var callbackResult: NetworkAsset? = null
     private lateinit var callbackException: TPException
 
     @Before
     fun createService() {
         mockWebServer = MockWebServer()
         runBlocking {
-            callbackResponse = object : VideoNetworkDataSource.TPResponse<NetworkVideo> {
-                override fun onSuccess(result: NetworkVideo) {
+            callbackResponse = object : VideoNetworkDataSource.TPResponse<NetworkAsset> {
+                override fun onSuccess(result: NetworkAsset) {
                     callbackResult = result
                 }
 
@@ -67,7 +67,7 @@ class NetworkTest {
         mockWebServer.takeRequest()
         assertEquals(response?.title, "BigBuckBunny.mp4")
         assertEquals(
-            response?.networkVideoContent?.dash_url,
+            response?.networkVideo?.dash_url,
             "https://d3cydmgt9q030i.cloudfront.net/transcoded/73633fa3-61c6-443c-b625-ac4e85b28cfc/video.mpd"
         )
     }


### PR DESCRIPTION
 - Despite NetworkVideo being mapped to Asset in TPStreams and ChapterContent in Testpress, its name and the presence of the NetworkVideoContent field inside it, are confusing.
- To simplify and prepare for the addition of NetworkLiveStream in the future, I have renamed NetworkVideo to NetworkAsset and NetworkVideoContent to NetworkVideo in this commit.