### PR TITLE
refactor: Rename VideoNetworkDataSource back to NetworkClient

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -6,7 +6,7 @@ import android.os.Looper
 import com.google.common.collect.ImmutableList
 import com.tpstream.player.data.Video
 import com.tpstream.player.data.VideoRepository
-import com.tpstream.player.data.source.network.NetworkClient
+import com.tpstream.player.util.NetworkClient
 import com.tpstream.player.offline.DownloadTask
 import com.tpstream.player.offline.VideoDownload
 import com.tpstream.player.offline.VideoDownloadManager

--- a/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
@@ -8,7 +8,7 @@ import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpInitParams
 import com.tpstream.player.data.source.local.TPStreamsDatabase
 import com.tpstream.player.data.source.network.NetworkAsset
-import com.tpstream.player.data.source.network.NetworkClient
+import com.tpstream.player.util.NetworkClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 

--- a/player/src/main/java/com/tpstream/player/util/NetworkClient.kt
+++ b/player/src/main/java/com/tpstream/player/util/NetworkClient.kt
@@ -1,4 +1,4 @@
-package com.tpstream.player.data.source.network
+package com.tpstream.player.util
 
 import com.google.gson.Gson
 import com.google.gson.JsonParseException

--- a/player/src/test/java/com/tpstream/player/NetworkTest.kt
+++ b/player/src/test/java/com/tpstream/player/NetworkTest.kt
@@ -2,7 +2,7 @@ package com.tpstream.player
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.tpstream.player.data.source.network.NetworkAsset
-import com.tpstream.player.data.source.network.NetworkClient
+import com.tpstream.player.util.NetworkClient
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse


### PR DESCRIPTION
- In this commit 1824004, we've renamed "Network" a generic utils class for making network calls to VideoNetworkDataSource to use it in the videoRepository, but this name doesn't reflect the class and also it would be confusing if we indent to use it somewhere else other video related. so renaming this class NetworkClient and moving it into the util folder.