### PR TITLE
refactor: Update id Field in Video Data Class to Store Asset ID

### DIFF
--- a/app/src/main/java/com/tpstream/app/DownloadListActivity.kt
+++ b/app/src/main/java/com/tpstream/app/DownloadListActivity.kt
@@ -133,7 +133,7 @@ class DownloadListActivity : AppCompatActivity() {
             val intent = Intent(this@DownloadListActivity, PlayerActivity::class.java)
             intent.putExtra(
                 TP_OFFLINE_PARAMS,
-                TpInitParams.createOfflineParams(video.videoId)
+                TpInitParams.createOfflineParams(video.id)
             )
             startActivity(intent)
         }
@@ -152,7 +152,7 @@ class DownloadListActivity : AppCompatActivity() {
             override fun areContentsTheSame(
                 oldItem: Video,
                 newItem: Video
-            ): Boolean = oldItem.videoId == newItem.videoId
+            ): Boolean = oldItem.id == newItem.id
         }
     }
 }

--- a/player/src/androidTest/java/com/tpstream/player/data/source/local/VideoDaoTest.kt
+++ b/player/src/androidTest/java/com/tpstream/player/data/source/local/VideoDaoTest.kt
@@ -70,13 +70,13 @@ class VideoDaoTest {
     @Throws(Exception::class)
     fun testDelete() = runBlocking {
         insertData()
-        val video4 = Video(id = 4L, videoId = "VideoID_4")
+        val video4 = Video(id = "VideoID_4")
         videoDao.insert(video4.asLocalVideo())
         // Check data added
         val beforeResult = videoDao.getAllVideo()
         assertThat(beforeResult?.size, equalTo(4))
         // Delete one data
-        videoDao.delete(video4.videoId)
+        videoDao.delete(video4.id)
         // Check deleted
         val afterResult = videoDao.getAllVideo()
         assertThat(afterResult?.size, equalTo(3))
@@ -93,8 +93,7 @@ class VideoDaoTest {
             val liveData = Transformations.map(videoDao.getVideoById("VideoID_1")) { it?.asDomainVideo() }
             val observer = Observer<Video?> { result ->
                 assertNotNull(result)
-                assertEquals(1L, result.id)
-                assertEquals("VideoID_1", result.videoId)
+                assertEquals("VideoID_1", result.id)
             }
             liveData.observeForever(observer)
             // Cleanup
@@ -111,7 +110,7 @@ class VideoDaoTest {
             val observer = Observer<List<Video>?> { result ->
                 assertNotNull(result)
                 assertEquals(3, result.size)
-                assertEquals("VideoID_1", result[0].videoId)
+                assertEquals("VideoID_1", result[0].id)
             }
             liveData.observeForever(observer)
             // Cleanup
@@ -120,9 +119,9 @@ class VideoDaoTest {
     }
 
     private fun insertData() = runBlocking {
-        val video1 = Video(id = 1L, videoId = "VideoID_1", url = "url_1")
-        val video2 = Video(id = 2L, videoId = "VideoID_2", url = "url_2")
-        val video3 = Video(id = 3L, videoId = "VideoID_3", url = "url_3")
+        val video1 = Video(id = "VideoID_1", url = "url_1")
+        val video2 = Video(id = "VideoID_2", url = "url_2")
+        val video3 = Video(id = "VideoID_3", url = "url_3")
         // Add data to db
         videoDao.insert(video1.asLocalVideo())
         videoDao.insert(video2.asLocalVideo())

--- a/player/src/main/java/com/tpstream/player/data/Video.kt
+++ b/player/src/main/java/com/tpstream/player/data/Video.kt
@@ -6,8 +6,7 @@ import com.tpstream.player.util.ImageSaver
 import com.tpstream.player.data.source.local.DownloadStatus
 
 data class Video(
-    internal var id:Long? = null,
-    var videoId: String = "",
+    var id: String = "",
     var title: String = "",
     var thumbnail: String = "",
     internal var url: String = "",
@@ -23,7 +22,7 @@ data class Video(
 ) {
 
     fun getLocalThumbnail(context: Context): Bitmap?{
-        return ImageSaver(context).load(videoId)
+        return ImageSaver(context).load(id)
     }
 
 }

--- a/player/src/main/java/com/tpstream/player/data/VideoModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoModelMapping.kt
@@ -6,8 +6,7 @@ import com.tpstream.player.data.source.network.NetworkAsset
 // LocalVideo to Video
 internal fun LocalVideo.asDomainVideo(): Video {
     return Video(
-        id = this.id,
-        videoId = this.videoId,
+        id = this.videoId,
         title = this.title,
         thumbnail = this.thumbnail,
         url = this.url,
@@ -36,7 +35,7 @@ internal fun NetworkAsset.asDomainVideo(): Video {
         dashUrl ?: url ?: ""
     }
     return Video(
-        videoId = this.id ?: "",
+        id = this.id ?: "",
         title = this.title ?: "",
         thumbnail = thumbnailUrl,
         url = url,
@@ -49,7 +48,7 @@ internal fun NetworkAsset.asDomainVideo(): Video {
 //Video to LocalVideo
 internal fun Video.asLocalVideo(): LocalVideo {
     return LocalVideo(
-        videoId = this.videoId,
+        videoId = this.id,
         title = this.title,
         thumbnail = this.thumbnail,
         url = this.url,

--- a/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
@@ -35,7 +35,7 @@ internal class VideoRepository(context: Context) {
     }
 
     suspend fun delete(video: Video){
-        videoDao.delete(video.videoId)
+        videoDao.delete(video.id)
     }
 
     suspend fun deleteAll(){
@@ -76,7 +76,7 @@ internal class VideoRepository(context: Context) {
         NetworkClient<NetworkAsset>().get(url, object : NetworkClient.TPResponse<NetworkAsset> {
             override fun onSuccess(result: NetworkAsset) {
                 val video = result.asDomainVideo()
-                video.videoId = params.videoId!!
+                video.id = params.videoId!!
                 callback.onSuccess(video)
             }
 

--- a/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
+++ b/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
@@ -32,7 +32,7 @@ class TpStreamDownloadManager(val context: Context) {
     fun deleteDownload(video: Video) {
         CoroutineScope(Dispatchers.IO).launch {
             DownloadTask(context).delete(video)
-            ImageSaver(context).delete(video.videoId)
+            ImageSaver(context).delete(video.id)
             videoRepository.delete(video)
         }
     }

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadService.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadService.kt
@@ -72,7 +72,7 @@ internal class VideoDownloadService: DownloadService(
         var videoId : String?
 
         runBlocking(Dispatchers.IO) {
-            videoId = videoRepository.getVideoByUrl(download.request.uri.toString())?.videoId
+            videoId = videoRepository.getVideoByUrl(download.request.uri.toString())?.id
         }
 
         when (download.state) {

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -109,10 +109,10 @@ class TPStreamPlayerView @JvmOverloads constructor(
                 downloadResolutionSelectionSheet.show((context as FragmentActivity).supportFragmentManager, "DownloadSelectionSheet")
                 downloadResolutionSelectionSheet.setOnSubmitListener { downloadRequest, video ->
                     DownloadTask(context).start(downloadRequest)
-                    video?.videoId = player.params.videoId!!
+                    video?.id = player.params.videoId!!
                     ImageSaver(context).save(
                         video?.thumbnail!!,
-                        video.videoId
+                        video.id
                     )
                     videoViewModel.insert(video)
                 }
@@ -232,7 +232,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
     }
 
     private fun updateDownloadButtonImage(){
-        videoViewModel.get(player.video?.videoId!!).observe(context as FragmentActivity) { video ->
+        videoViewModel.get(player.video?.id!!).observe(context as FragmentActivity) { video ->
             downloadState = when (video?.downloadState) {
                 DownloadStatus.DOWNLOADING ->{
                     downloadButton?.setImageResource(R.drawable.ic_baseline_downloading_24)


### PR DESCRIPTION
- Previously the Video data class had both "id" and "videoId" fields. In this commit, we addressed confusion by modifying the Video data class to use "id" for storing asset ID or ChapterContent UUID, as the existing "id" was not used elsewhere.
-  This change simplifies usage, eliminating ambiguity about which field to use in different contexts.