### PR TITLE
refactor: Replace Video usage with Asset data class

### DIFF
--- a/app/src/main/java/com/tpstream/app/DownloadListActivity.kt
+++ b/app/src/main/java/com/tpstream/app/DownloadListActivity.kt
@@ -17,7 +17,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.tpstream.app.databinding.ActivityDownloadListBinding
 import com.tpstream.app.databinding.DownloadItemBinding
 import com.tpstream.player.TpInitParams
-import com.tpstream.player.data.Video
+import com.tpstream.player.data.Asset
 import com.tpstream.player.data.source.local.DownloadStatus
 
 class DownloadListActivity : AppCompatActivity() {
@@ -47,8 +47,8 @@ class DownloadListActivity : AppCompatActivity() {
     }
 
     inner class DownloadListAdapter(
-        private val data: List<Video>
-    ) : ListAdapter<Video, DownloadListAdapter.DownloadListViewHolder>(
+        private val data: List<Asset>
+    ) : ListAdapter<Asset, DownloadListAdapter.DownloadListViewHolder>(
         DOWNLOAD_COMPARATOR
     ) {
 
@@ -61,13 +61,13 @@ class DownloadListActivity : AppCompatActivity() {
             val resumeButton: Button = binding.resumeButton
             val thumbnail: ImageView = binding.thumbnail
 
-            fun bind(video: Video) {
-                binding.title.text = video.title
-                thumbnail.setImageBitmap(video.getLocalThumbnail(applicationContext))
-                binding.downloadImage.setImageResource(getDownloadImage(video.downloadState))
-                binding.duration.text = video.duration
-                binding.percentage.text = "${video.percentageDownloaded} %"
-                showOrHideButtons(video.downloadState)
+            fun bind(asset: Asset) {
+                binding.title.text = asset.title
+                thumbnail.setImageBitmap(asset.getLocalThumbnail(applicationContext))
+                binding.downloadImage.setImageResource(getDownloadImage(asset.video.downloadState))
+                binding.duration.text = asset.video.duration
+                binding.percentage.text = "${asset.video.percentageDownloaded} %"
+                showOrHideButtons(asset.video.downloadState)
             }
 
             private fun getDownloadImage(videoState: DownloadStatus?): Int {
@@ -114,26 +114,26 @@ class DownloadListActivity : AppCompatActivity() {
         }
 
         override fun onBindViewHolder(holder: DownloadListViewHolder, position: Int) {
-            val video = data[position]
-            holder.bind(video)
-            holder.deleteButton.setOnClickListener { downloadListViewModel.deleteDownload(video) }
-            holder.cancelButton.setOnClickListener { downloadListViewModel.cancelDownload(video) }
-            holder.pauseButton.setOnClickListener { downloadListViewModel.pauseDownload(video) }
-            holder.resumeButton.setOnClickListener { downloadListViewModel.resumeDownload(video) }
+            val asset = data[position]
+            holder.bind(asset)
+            holder.deleteButton.setOnClickListener { downloadListViewModel.deleteDownload(asset) }
+            holder.cancelButton.setOnClickListener { downloadListViewModel.cancelDownload(asset) }
+            holder.pauseButton.setOnClickListener { downloadListViewModel.pauseDownload(asset) }
+            holder.resumeButton.setOnClickListener { downloadListViewModel.resumeDownload(asset) }
             holder.thumbnail.setOnClickListener {
-                if (video.downloadState == DownloadStatus.COMPLETE) {
-                    playVideo(video)
+                if (asset.video.downloadState == DownloadStatus.COMPLETE) {
+                    playVideo(asset)
                 } else {
                     Toast.makeText(applicationContext, "Downloading", Toast.LENGTH_SHORT).show()
                 }
             }
         }
 
-        private fun playVideo(video: Video) {
+        private fun playVideo(asset: Asset) {
             val intent = Intent(this@DownloadListActivity, PlayerActivity::class.java)
             intent.putExtra(
                 TP_OFFLINE_PARAMS,
-                TpInitParams.createOfflineParams(video.id)
+                TpInitParams.createOfflineParams(asset.id)
             )
             startActivity(intent)
         }
@@ -143,15 +143,15 @@ class DownloadListActivity : AppCompatActivity() {
 
     companion object {
 
-        private val DOWNLOAD_COMPARATOR = object : DiffUtil.ItemCallback<Video>() {
+        private val DOWNLOAD_COMPARATOR = object : DiffUtil.ItemCallback<Asset>() {
             override fun areItemsTheSame(
-                oldItem: Video,
-                newItem: Video
+                oldItem: Asset,
+                newItem: Asset
             ): Boolean = oldItem == newItem
 
             override fun areContentsTheSame(
-                oldItem: Video,
-                newItem: Video
+                oldItem: Asset,
+                newItem: Asset
             ): Boolean = oldItem.id == newItem.id
         }
     }

--- a/app/src/main/java/com/tpstream/app/DownloadListViewModel.kt
+++ b/app/src/main/java/com/tpstream/app/DownloadListViewModel.kt
@@ -4,30 +4,30 @@ import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import com.tpstream.player.offline.TpStreamDownloadManager
-import com.tpstream.player.data.Video
+import com.tpstream.player.data.Asset
 
 class DownloadListViewModel(context: Context): ViewModel() {
 
     private var tpStreamDownloadManager: TpStreamDownloadManager = TpStreamDownloadManager(context)
 
-    fun getDownloadData(): LiveData<List<Video>?> {
+    fun getDownloadData(): LiveData<List<Asset>?> {
         return tpStreamDownloadManager.getAllDownloads()
     }
 
-    fun pauseDownload(video: Video) {
-        tpStreamDownloadManager.pauseDownload(video)
+    fun pauseDownload(asset: Asset) {
+        tpStreamDownloadManager.pauseDownload(asset)
     }
 
-    fun resumeDownload(video: Video) {
-        tpStreamDownloadManager.resumeDownload(video)
+    fun resumeDownload(asset: Asset) {
+        tpStreamDownloadManager.resumeDownload(asset)
     }
 
-    fun cancelDownload(video: Video) {
-        tpStreamDownloadManager.cancelDownload(video)
+    fun cancelDownload(asset: Asset) {
+        tpStreamDownloadManager.cancelDownload(asset)
     }
 
-    fun deleteDownload(video: Video) {
-        tpStreamDownloadManager.deleteDownload(video)
+    fun deleteDownload(asset: Asset) {
+        tpStreamDownloadManager.deleteDownload(asset)
     }
 
     fun deleteAllDownload() {

--- a/player/src/androidTest/java/com/tpstream/player/data/source/local/VideoDaoTest.kt
+++ b/player/src/androidTest/java/com/tpstream/player/data/source/local/VideoDaoTest.kt
@@ -6,9 +6,10 @@ import androidx.lifecycle.Transformations
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tpstream.player.data.Asset
 import com.tpstream.player.data.Video
-import com.tpstream.player.data.asDomainVideo
-import com.tpstream.player.data.asDomainVideos
+import com.tpstream.player.data.asDomainAsset
+import com.tpstream.player.data.asDomainAssets
 import com.tpstream.player.data.asLocalVideo
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
@@ -70,13 +71,13 @@ class VideoDaoTest {
     @Throws(Exception::class)
     fun testDelete() = runBlocking {
         insertData()
-        val video4 = Video(id = "VideoID_4")
-        videoDao.insert(video4.asLocalVideo())
+        val asset4 = Asset(id = "VideoID_4")
+        videoDao.insert(asset4.asLocalVideo())
         // Check data added
         val beforeResult = videoDao.getAllVideo()
         assertThat(beforeResult?.size, equalTo(4))
         // Delete one data
-        videoDao.delete(video4.id)
+        videoDao.delete(asset4.id)
         // Check deleted
         val afterResult = videoDao.getAllVideo()
         assertThat(afterResult?.size, equalTo(3))
@@ -90,8 +91,8 @@ class VideoDaoTest {
     fun testGetOfflineVideoInfoById() {
         insertData()
         CoroutineScope(Dispatchers.Main).launch {
-            val liveData = Transformations.map(videoDao.getVideoById("VideoID_1")) { it?.asDomainVideo() }
-            val observer = Observer<Video?> { result ->
+            val liveData = Transformations.map(videoDao.getVideoById("VideoID_1")) { it?.asDomainAsset() }
+            val observer = Observer<Asset?> { result ->
                 assertNotNull(result)
                 assertEquals("VideoID_1", result.id)
             }
@@ -106,8 +107,8 @@ class VideoDaoTest {
     fun testGetAllDownloadInLiveData() {
         insertData()
         CoroutineScope(Dispatchers.Main).launch {
-            val liveData = Transformations.map(videoDao.getAllDownloadInLiveData()) { it?.asDomainVideos() }
-            val observer = Observer<List<Video>?> { result ->
+            val liveData = Transformations.map(videoDao.getAllDownloadInLiveData()) { it?.asDomainAssets() }
+            val observer = Observer<List<Asset>?> { result ->
                 assertNotNull(result)
                 assertEquals(3, result.size)
                 assertEquals("VideoID_1", result[0].id)
@@ -119,13 +120,13 @@ class VideoDaoTest {
     }
 
     private fun insertData() = runBlocking {
-        val video1 = Video(id = "VideoID_1", url = "url_1")
-        val video2 = Video(id = "VideoID_2", url = "url_2")
-        val video3 = Video(id = "VideoID_3", url = "url_3")
+        val asset1 = Asset(id = "VideoID_1", video = Video(url = "url_1"))
+        val asset2 = Asset(id = "VideoID_2", video = Video(url = "url_1"))
+        val asset3 = Asset(id = "VideoID_3", video = Video(url = "url_1"))
         // Add data to db
-        videoDao.insert(video1.asLocalVideo())
-        videoDao.insert(video2.asLocalVideo())
-        videoDao.insert(video3.asLocalVideo())
+        videoDao.insert(asset1.asLocalVideo())
+        videoDao.insert(asset2.asLocalVideo())
+        videoDao.insert(asset3.asLocalVideo())
     }
 
 }

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import com.google.common.collect.ImmutableList
-import com.tpstream.player.data.Video
+import com.tpstream.player.data.Asset
 import com.tpstream.player.data.VideoRepository
 import com.tpstream.player.util.NetworkClient
 import com.tpstream.player.offline.DownloadTask
@@ -50,7 +50,7 @@ public interface TpStreamPlayer {
 
 internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
     lateinit var params: TpInitParams
-    var video: Video? = null
+    var asset: Asset? = null
     var _listener: TPStreamPlayerListener? = null
     lateinit var exoPlayer: ExoPlayer
     private val exoPlayerListener:ExoPlayerListenerWrapper = ExoPlayerListenerWrapper(this)
@@ -77,10 +77,10 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
     override fun load(parameters: TpInitParams) {
         params = parameters
         exoPlayer.playWhenReady = parameters.autoPlay?:true
-        videoRepository.getVideo(parameters, object : NetworkClient.TPResponse<Video> {
-            override fun onSuccess(result: Video) {
-                video = result
-                playVideoInUIThread(result.url, parameters.startPositionInMilliSecs)
+        videoRepository.getVideo(parameters, object : NetworkClient.TPResponse<Asset> {
+            override fun onSuccess(result: Asset) {
+                asset = result
+                playVideoInUIThread(result.video.url, parameters.startPositionInMilliSecs)
                 loadCompleteListener?.onComplete()
             }
 

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -5,24 +5,26 @@ import android.graphics.Bitmap
 import com.tpstream.player.util.ImageSaver
 import com.tpstream.player.data.source.local.DownloadStatus
 
-data class Video(
+data class Asset(
     var id: String = "",
     var title: String = "",
     var thumbnail: String = "",
-    internal var url: String = "",
-    var duration: String = "",
     var description: String = "",
+    var video: Video = Video()
+) {
+    fun getLocalThumbnail(context: Context): Bitmap?{
+        return ImageSaver(context).load(id)
+    }
+}
+
+data class Video(
+    internal var url: String = "",
+    var width: Int = 0,
+    var height: Int = 0,
     var transcodingStatus: String = "",
+    var duration: String = "",
     var percentageDownloaded: Int = 0,
     var bytesDownloaded: Long = 0,
     var totalSize: Long = 0,
     var downloadState: DownloadStatus? = null,
-    var videoWidth: Int = 0,
-    var videoHeight: Int = 0
-) {
-
-    fun getLocalThumbnail(context: Context): Bitmap?{
-        return ImageSaver(context).load(id)
-    }
-
-}
+)

--- a/player/src/main/java/com/tpstream/player/data/VideoModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoModelMapping.kt
@@ -4,28 +4,30 @@ import com.tpstream.player.data.source.local.LocalVideo
 import com.tpstream.player.data.source.network.NetworkAsset
 
 // LocalVideo to Video
-internal fun LocalVideo.asDomainVideo(): Video {
-    return Video(
+internal fun LocalVideo.asDomainAsset(): Asset {
+    return Asset(
         id = this.videoId,
         title = this.title,
-        thumbnail = this.thumbnail,
-        url = this.url,
-        duration = this.duration,
         description = this.description,
-        transcodingStatus = this.transcodingStatus,
-        percentageDownloaded = this.percentageDownloaded,
-        bytesDownloaded = this.bytesDownloaded,
-        totalSize = this.totalSize,
-        downloadState = this.downloadState,
-        videoWidth = this.videoWidth,
-        videoHeight = this.videoHeight
+        thumbnail = this.thumbnail,
+        video = Video(
+            url = this.url,
+            duration = this.duration,
+            transcodingStatus = this.transcodingStatus,
+            percentageDownloaded = this.percentageDownloaded,
+            bytesDownloaded = this.bytesDownloaded,
+            totalSize = this.totalSize,
+            downloadState = this.downloadState,
+            width = this.videoWidth,
+            height = this.videoHeight,
+        )
     )
 }
 
-internal fun List<LocalVideo>.asDomainVideos() = map(LocalVideo::asDomainVideo)
+internal fun List<LocalVideo>.asDomainAssets() = map(LocalVideo::asDomainAsset)
 
 //NetworkVideo to Video
-internal fun NetworkAsset.asDomainVideo(): Video {
+internal fun NetworkAsset.asDomainAsset(): Asset {
     val thumbnailUrl = if (networkVideo != null) networkVideo.preview_thumbnail_url
         ?: "" else thumbnail ?: ""
     val url = if (networkVideo != null) {
@@ -34,32 +36,34 @@ internal fun NetworkAsset.asDomainVideo(): Video {
     } else {
         dashUrl ?: url ?: ""
     }
-    return Video(
+    return Asset(
         id = this.id ?: "",
         title = this.title ?: "",
         thumbnail = thumbnailUrl,
-        url = url,
-        duration = duration ?: "",
+        video = Video(
+            url = url,
+            duration = duration ?: "",
+            transcodingStatus = transcodingStatus ?: ""
+        ),
         description = description ?: "",
-        transcodingStatus = transcodingStatus ?: ""
     )
 }
 
 //Video to LocalVideo
-internal fun Video.asLocalVideo(): LocalVideo {
+internal fun Asset.asLocalVideo(): LocalVideo {
     return LocalVideo(
         videoId = this.id,
         title = this.title,
         thumbnail = this.thumbnail,
-        url = this.url,
-        duration = this.duration,
+        url = this.video.url,
+        duration = this.video.duration,
         description = this.description,
-        transcodingStatus = this.transcodingStatus,
-        percentageDownloaded = this.percentageDownloaded,
-        bytesDownloaded = this.bytesDownloaded,
-        totalSize = this.totalSize,
-        downloadState = this.downloadState,
-        videoWidth = this.videoWidth,
-        videoHeight = this.videoHeight
+        transcodingStatus = this.video.transcodingStatus,
+        percentageDownloaded = this.video.percentageDownloaded,
+        bytesDownloaded = this.video.bytesDownloaded,
+        totalSize = this.video.totalSize,
+        downloadState = this.video.downloadState,
+        videoWidth = this.video.width,
+        videoHeight = this.video.height
     )
 }

--- a/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/VideoRepository.kt
@@ -16,41 +16,41 @@ internal class VideoRepository(context: Context) {
 
     private val videoDao = TPStreamsDatabase(context).videoDao()
 
-    suspend fun update(video: Video){
-        videoDao.insert(video.asLocalVideo())
+    suspend fun update(asset: Asset){
+        videoDao.insert(asset.asLocalVideo())
     }
 
-    fun get(videoId: String): LiveData<Video?> {
+    fun get(videoId: String): LiveData<Asset?> {
         return Transformations.map(videoDao.getVideoById(videoId)) {
-            it?.asDomainVideo()
+            it?.asDomainAsset()
         }
     }
 
-    fun getVideoByUrl(url:String):Video? {
-        return videoDao.getVideoByUrl(url)?.asDomainVideo()
+    fun getVideoByUrl(url:String):Asset? {
+        return videoDao.getVideoByUrl(url)?.asDomainAsset()
     }
 
-    suspend fun insert(video: Video){
-        videoDao.insert(video.asLocalVideo())
+    suspend fun insert(asset: Asset){
+        videoDao.insert(asset.asLocalVideo())
     }
 
-    suspend fun delete(video: Video){
-        videoDao.delete(video.id)
+    suspend fun delete(asset: Asset){
+        videoDao.delete(asset.id)
     }
 
     suspend fun deleteAll(){
         videoDao.deleteAll()
     }
 
-    fun getAllDownloadsInLiveData():LiveData<List<Video>?>{
+    fun getAllDownloadsInLiveData():LiveData<List<Asset>?>{
         return Transformations.map(videoDao.getAllDownloadInLiveData()) {
-            it?.asDomainVideos()
+            it?.asDomainAssets()
         }
     }
 
     fun getVideo(
         params: TpInitParams,
-        callback : NetworkClient.TPResponse<Video>
+        callback : NetworkClient.TPResponse<Asset>
     ){
         val video = getVideoFromDB(params)
         if (video != null) {
@@ -60,22 +60,22 @@ internal class VideoRepository(context: Context) {
         }
     }
 
-    private fun getVideoFromDB(params: TpInitParams): Video?{
-        var video : Video? = null
+    private fun getVideoFromDB(params: TpInitParams): Asset?{
+        var asset : Asset? = null
         runBlocking(Dispatchers.IO) {
-            video = videoDao.getVideoByVideoId(params.videoId!!)?.asDomainVideo()
+            asset = videoDao.getVideoByVideoId(params.videoId!!)?.asDomainAsset()
         }
-        return video
+        return asset
     }
 
     private fun fetchVideo(
         params: TpInitParams,
-        callback : NetworkClient.TPResponse<Video>
+        callback : NetworkClient.TPResponse<Asset>
     ) {
         val url = TPStreamsSDK.constructVideoInfoUrl(params.videoId, params.accessToken)
         NetworkClient<NetworkAsset>().get(url, object : NetworkClient.TPResponse<NetworkAsset> {
             override fun onSuccess(result: NetworkAsset) {
-                val video = result.asDomainVideo()
+                val video = result.asDomainAsset()
                 video.id = params.videoId!!
                 callback.onSuccess(video)
             }

--- a/player/src/main/java/com/tpstream/player/offline/DownloadTask.kt
+++ b/player/src/main/java/com/tpstream/player/offline/DownloadTask.kt
@@ -3,7 +3,7 @@ package com.tpstream.player.offline
 
 import android.content.Context
 import com.tpstream.player.*
-import com.tpstream.player.data.Video
+import com.tpstream.player.data.Asset
 
 internal class DownloadTask (val context: Context) {
 
@@ -19,8 +19,8 @@ internal class DownloadTask (val context: Context) {
         )
     }
 
-    fun pause(video: Video) {
-        val download = downloadIndex.getDownload(video.url)
+    fun pause(asset: Asset) {
+        val download = downloadIndex.getDownload(asset.video.url)
         val STOP_REASON_PAUSED = 1
         download?.let {
             DownloadService.sendSetStopReason(
@@ -33,8 +33,8 @@ internal class DownloadTask (val context: Context) {
         }
     }
 
-    fun resume(video: Video) {
-        val download = downloadIndex.getDownload(video.url)
+    fun resume(asset: Asset) {
+        val download = downloadIndex.getDownload(asset.video.url)
         download?.let {
             DownloadService.sendSetStopReason(
                 context,
@@ -46,8 +46,8 @@ internal class DownloadTask (val context: Context) {
         }
     }
 
-    fun delete(video: Video) {
-        val download = downloadIndex.getDownload(video.url)
+    fun delete(asset: Asset) {
+        val download = downloadIndex.getDownload(asset.video.url)
         download?.let {
             DownloadService.sendRemoveDownload(
                 context,

--- a/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
+++ b/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
@@ -3,7 +3,7 @@ package com.tpstream.player.offline
 import android.content.Context
 import androidx.lifecycle.LiveData
 import com.tpstream.player.util.ImageSaver
-import com.tpstream.player.data.Video
+import com.tpstream.player.data.Asset
 import com.tpstream.player.data.VideoRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -13,27 +13,27 @@ class TpStreamDownloadManager(val context: Context) {
 
     private val videoRepository = VideoRepository(context)
 
-    fun getAllDownloads(): LiveData<List<Video>?> {
+    fun getAllDownloads(): LiveData<List<Asset>?> {
         return videoRepository.getAllDownloadsInLiveData()
     }
 
-    fun pauseDownload(video: Video) {
-        DownloadTask(context).pause(video)
+    fun pauseDownload(asset: Asset) {
+        DownloadTask(context).pause(asset)
     }
 
-    fun resumeDownload(video: Video) {
-        DownloadTask(context).resume(video)
+    fun resumeDownload(asset: Asset) {
+        DownloadTask(context).resume(asset)
     }
 
-    fun cancelDownload(video: Video) {
-        deleteDownload(video)
+    fun cancelDownload(asset: Asset) {
+        deleteDownload(asset)
     }
 
-    fun deleteDownload(video: Video) {
+    fun deleteDownload(asset: Asset) {
         CoroutineScope(Dispatchers.IO).launch {
-            DownloadTask(context).delete(video)
-            ImageSaver(context).delete(video.id)
-            videoRepository.delete(video)
+            DownloadTask(context).delete(asset)
+            ImageSaver(context).delete(asset.id)
+            videoRepository.delete(asset)
         }
     }
 

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -23,7 +23,7 @@ internal class VideoDownloadRequestCreationHandler(
     private var keySetId: ByteArray? = null
 
     init {
-        val url = player.video?.url!!
+        val url = player.asset?.video?.url!!
         trackSelectionParameters = DownloadHelper.getDefaultTrackSelectorParameters(context)
         val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(player.params.videoId, player.params.accessToken)
         mediaItem = MediaItemBuilder()
@@ -85,7 +85,7 @@ internal class VideoDownloadRequestCreationHandler(
 
     fun buildDownloadRequest(overrides: MutableMap<TrackGroup, TrackSelectionOverride>): DownloadRequest {
         setSelectedTracks(overrides)
-        val name = player.video?.title!!
+        val name = player.asset?.title!!
         return downloadHelper.getDownloadRequest(Util.getUtf8Bytes(name)).copyWithKeySetId(keySetId)
     }
 

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadService.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadService.kt
@@ -118,13 +118,13 @@ internal class VideoDownloadService: DownloadService(
 
     private fun updateDownloadStatus(download:Download){
         CoroutineScope(Dispatchers.IO).launch{
-            val video = videoRepository.getVideoByUrl(download.request.uri.toString())
-            video?.let {
-                video.percentageDownloaded = download.percentDownloaded.toInt()
-                video.bytesDownloaded = download.bytesDownloaded
-                video.totalSize = download.contentLength
-                video.downloadState = getVideoState(download.state)
-                videoRepository.update(video)
+            val asset = videoRepository.getVideoByUrl(download.request.uri.toString())
+            asset?.let {
+                asset.video.percentageDownloaded = download.percentDownloaded.toInt()
+                asset.video.bytesDownloaded = download.bytesDownloaded
+                asset.video.totalSize = download.contentLength
+                asset.video.downloadState = getVideoState(download.state)
+                videoRepository.update(asset)
             }
         }
     }

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -16,12 +16,12 @@ import com.google.common.collect.ImmutableList
 import com.tpstream.player.*
 import com.tpstream.player.R
 import com.tpstream.player.databinding.TpDownloadTrackSelectionDialogBinding
-import com.tpstream.player.data.Video
+import com.tpstream.player.data.Asset
 import com.tpstream.player.offline.VideoDownloadRequestCreationHandler
 import okio.IOException
 import kotlin.math.roundToInt
 
-internal typealias OnSubmitListener = (DownloadRequest,Video?) -> Unit
+internal typealias OnSubmitListener = (DownloadRequest, Asset?) -> Unit
 
 internal class DownloadResolutionSelectionSheet(
     val player: TpStreamPlayerImpl,
@@ -30,7 +30,7 @@ internal class DownloadResolutionSelectionSheet(
 
     private var _binding: TpDownloadTrackSelectionDialogBinding? = null
     private val binding get() = _binding!!
-    private val video = player.video
+    private val asset = player.asset
     private lateinit var videoDownloadRequestCreateHandler: VideoDownloadRequestCreationHandler
     var overrides: MutableMap<TrackGroup, TrackSelectionOverride> =
         parameters.overrides.toMutableMap()
@@ -113,7 +113,7 @@ internal class DownloadResolutionSelectionSheet(
             if (isResolutionSelected){
                 val downloadRequest =
                     videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
-                onSubmitListener?.invoke(downloadRequest,video)
+                onSubmitListener?.invoke(downloadRequest,asset)
                 Toast.makeText(requireContext(), "Download Start", Toast.LENGTH_SHORT).show()
                 dismiss()
             } else {

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -100,7 +100,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
             else -> {
                 EncryptionKeyRepository(context).fetchAndStore(
                     player.params,
-                    player.video?.url!!
+                    player.asset?.video?.url!!
                 )
                 val downloadResolutionSelectionSheet = DownloadResolutionSelectionSheet(
                     player,
@@ -232,8 +232,8 @@ class TPStreamPlayerView @JvmOverloads constructor(
     }
 
     private fun updateDownloadButtonImage(){
-        videoViewModel.get(player.video?.id!!).observe(context as FragmentActivity) { video ->
-            downloadState = when (video?.downloadState) {
+        videoViewModel.get(player.asset?.id!!).observe(context as FragmentActivity) { asset ->
+            downloadState = when (asset?.video?.downloadState) {
                 DownloadStatus.DOWNLOADING ->{
                     downloadButton?.setImageResource(R.drawable.ic_baseline_downloading_24)
                     DownloadStatus.DOWNLOADING

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -196,7 +196,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private fun reloadVideo(){
         val currentPosition = player?.getCurrentTime()
         val tpImp = player as TpStreamPlayerImpl
-        tpImp.playVideo(player?.video?.url!!,currentPosition!!)
+        tpImp.playVideo(player?.asset?.video?.url!!,currentPosition!!)
     }
 
     private fun storeCurrentPlayTime(){
@@ -286,7 +286,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
                 showErrorMessage(TPException.networkError(IOException()).getErrorMessage(errorPlayerId))
                 return
             }
-            val url = player?.video?.url
+            val url = player?.asset?.video?.url
             val downloadTask = DownloadTask(requireContext())
             drmLicenseRetries += 1
             if (drmLicenseRetries < 2 && downloadTask.isDownloaded(url!!)) {

--- a/player/src/main/java/com/tpstream/player/ui/viewmodel/VideoViewModel.kt
+++ b/player/src/main/java/com/tpstream/player/ui/viewmodel/VideoViewModel.kt
@@ -3,19 +3,19 @@ package com.tpstream.player.ui.viewmodel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.tpstream.player.data.Video
+import com.tpstream.player.data.Asset
 import com.tpstream.player.data.VideoRepository
 import kotlinx.coroutines.launch
 
 internal class VideoViewModel(private val videoRepository: VideoRepository):ViewModel() {
 
-    fun get(videoId: String): LiveData<Video?> {
+    fun get(videoId: String): LiveData<Asset?> {
         return videoRepository.get(videoId)
     }
 
-    fun insert(video: Video){
+    fun insert(asset: Asset){
         viewModelScope.launch{
-            videoRepository.insert(video)
+            videoRepository.insert(asset)
         }
     }
 


### PR DESCRIPTION
- Implemented a data class for Asset with a existing 'Video' as a field. Replaced the previous direct usage of 'Video' in the code with the new 'Asset' data class.
- This change is made to prepare for the future integration of 'LiveStream.' It wouldn't be logical to have a dedicated 'liveStream' field inside the 'Video' class.