### PR TITLE
refactor: Rename enum to constants directory

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -8,7 +8,7 @@ import android.util.Log
 import android.widget.Button
 import android.widget.Toast
 import com.tpstream.player.*
-import com.tpstream.player.enum.PlaybackError
+import com.tpstream.player.constants.PlaybackError
 import com.tpstream.player.ui.InitializationListener
 import com.tpstream.player.ui.TpStreamPlayerFragment
 

--- a/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
@@ -1,6 +1,6 @@
 package com.tpstream.player
 
-import com.tpstream.player.enum.PlaybackError
+import com.tpstream.player.constants.PlaybackError
 
 interface TPStreamPlayerListener {
     fun onTracksChanged(tracks: Tracks) {}

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -1,4 +1,4 @@
-package com.tpstream.player.enum
+package com.tpstream.player.constants
 
 import com.tpstream.player.PlaybackException
 import com.tpstream.player.TPException

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackSpeed.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackSpeed.kt
@@ -1,4 +1,4 @@
-package com.tpstream.player.enum
+package com.tpstream.player.constants
 
 internal enum class PlaybackSpeed(val value: Float, val text: String) {
     PLAYBACK_SPEED_0_25(0.25f, "0.25x"),

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -22,7 +22,7 @@ import com.tpstream.player.data.Asset
 import com.tpstream.player.data.AssetRepository
 import com.tpstream.player.data.source.local.DownloadStatus
 import com.tpstream.player.databinding.TpStreamPlayerViewBinding
-import com.tpstream.player.enum.PlaybackSpeed
+import com.tpstream.player.constants.PlaybackSpeed
 import com.tpstream.player.offline.DownloadTask
 import com.tpstream.player.ui.viewmodel.VideoViewModel
 import com.tpstream.player.util.ImageSaver

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -17,8 +17,8 @@ import androidx.fragment.app.Fragment
 import com.tpstream.player.*
 import com.tpstream.player.Util
 import com.tpstream.player.databinding.FragmentTpStreamPlayerBinding
-import com.tpstream.player.enum.getErrorMessage
-import com.tpstream.player.enum.toError
+import com.tpstream.player.constants.getErrorMessage
+import com.tpstream.player.constants.toError
 import com.tpstream.player.offline.*
 import com.tpstream.player.util.OrientationListener
 import com.tpstream.player.util.SentryLogger


### PR DESCRIPTION
- Renamed the directory from `enum` to `constants` as using `enum` as a directory name is not appropriate since it's a keyword in both Java and Kotlin.
- Additionally, using `enum` could lead to conflicts when implementing this package in Java code bases.