### PR TITLE
fix: Caption button showing even when captions are not available

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -7,7 +7,6 @@ import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.util.AttributeSet
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.*


### PR DESCRIPTION
- Previously, the caption button was displayed even if the video didn't have captions.
- In this commit, we updated the logic to show the caption button only when captions are available.