### PR TITLE
fix: Remove Hide System bars while opening player fragment

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -75,7 +75,6 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         if (Util.SDK_INT <= 23 || player == null) {
             initializePlayer()
         }
-        hideSystemUi()
     }
 
     override fun onPause() {
@@ -128,18 +127,6 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
             } else {
                 showFullScreen()
             }
-        }
-    }
-
-    private fun hideSystemUi() {
-        activity?.let { activity ->
-            WindowCompat.setDecorFitsSystemWindows(activity.window, false)
-            WindowInsetsControllerCompat(activity.window, tpStreamPlayerView).let { controller ->
-                controller.hide(WindowInsetsCompat.Type.systemBars())
-                controller.systemBarsBehavior =
-                    WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-            }
-            Log.d(TAG, "hideSystemUi: ")
         }
     }
 


### PR DESCRIPTION
- The status bar was being unnecessarily hidden when the player fragment was opened.
- This commit removes that operation.