### PR TITLE
fix: Add update method in `AssetDao`

### DIFF
--- a/player/src/main/java/com/tpstream/player/data/AssetRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/AssetRepository.kt
@@ -17,7 +17,7 @@ internal class AssetRepository(context: Context) {
     private val assetDao = TPStreamsDatabase(context).assetDao()
 
     suspend fun update(asset: Asset){
-        assetDao.insert(asset.asLocalAsset())
+        assetDao.update(asset.asLocalAsset())
     }
 
     fun get(videoId: String): LiveData<Asset?> {

--- a/player/src/main/java/com/tpstream/player/data/source/local/AssetDao.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/local/AssetDao.kt
@@ -1,16 +1,16 @@
 package com.tpstream.player.data.source.local
 
 import androidx.lifecycle.LiveData
-import androidx.room.Dao
-import androidx.room.Insert
-import androidx.room.OnConflictStrategy
-import androidx.room.Query
+import androidx.room.*
 
 @Dao
 internal interface AssetDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(asset: LocalAsset)
+
+    @Update()
+    suspend fun update(asset: LocalAsset)
 
     @Query("DELETE FROM Asset WHERE videoId=:videoID")
     suspend fun delete(videoID:String)


### PR DESCRIPTION
- Previously, while updating the `LocalAsset` in the Room database, we used the insert method. This caused the old object to be replaced by the new object each time, changing the order.
- We are using LiveData to retrieve all local assets, so the list order changed every time a `LocalAsset` object was updated.
- In this commit, we added an update method to ensure that the order remains consistent.