### PR TITLE
fix: Update download start time when download starts

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -100,9 +100,9 @@ class PlayerActivity : AppCompatActivity() {
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             "TPS_NON_DRM" -> {
-                accessToken = "48a481d0-7a7f-465f-9d18-86f52129430b"
-                videoId = "C65BJzhj48k"
-                orgCode = "dcek2m"
+                accessToken = "151e157d-d73e-4180-867f-c1819f4b2be5"
+                videoId = "rUxrJ4d7nzA"
+                orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}

--- a/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
@@ -54,8 +54,7 @@ internal fun NetworkAsset.asDomainAsset(): Asset {
             }
         ),
         description = description ?: "",
-        liveStream = getDomainLiveStream(this),
-        folderTree = folderTree
+        liveStream = getDomainLiveStream(this)
     )
 }
 


### PR DESCRIPTION
- Added `downloadStartTimeMs` field to `LocalAsset` model in commit f8941be.
- Updated `downloadStartTimeMs` field to track the actual start time of download processes.
