### PR TITLE
enhancement: Add support for filtering assets by metadata

### DIFF
--- a/app/src/main/java/com/tpstream/app/DownloadListViewModel.kt
+++ b/app/src/main/java/com/tpstream/app/DownloadListViewModel.kt
@@ -14,6 +14,10 @@ class DownloadListViewModel(context: Context): ViewModel() {
         return tpStreamDownloadManager.getAllDownloads()
     }
 
+    fun getAssetsByMetadata(metadata: Map<String, String>): LiveData<List<Asset>?> {
+        return tpStreamDownloadManager.getAssetsByMetadata(metadata)
+    }
+
     fun getDownloadAsset(assetId: String): LiveData<Asset?> {
         return tpStreamDownloadManager.getDownloadAsset(assetId)
     }

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -36,7 +36,7 @@ class PlayerActivity : AppCompatActivity() {
         playerFragment.setOnInitializationListener(object: InitializationListener {
             override fun onInitializationSuccess(player: TpStreamPlayer) {
                 tpStreamPlayer = player
-                tpStreamPlayer.load(buildParams(),"{\"videoID\":\"${buildParams().videoId}\"}")
+                tpStreamPlayer.load(buildParams())
                 tpStreamPlayer.setListener( object : TPStreamPlayerListener {
                     override fun onPlaybackStateChanged(playbackState: Int) {
                         Log.d(TAG, "onPlaybackStateChanged: $playbackState")

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -36,7 +36,7 @@ public interface TpStreamPlayer {
     fun setMaxResolution(resolution: Int)
     fun play()
     fun pause()
-    fun load(parameters: TpInitParams, metadata: String? = null)
+    fun load(parameters: TpInitParams, metadata: Map<String, String>? = null)
     fun release()
     fun getPlayBackSpeed(): Float
     fun getPlayWhenReady(): Boolean
@@ -75,7 +75,7 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
             }
     }
 
-    override fun load(parameters: TpInitParams, metadata: String?) {
+    override fun load(parameters: TpInitParams, metadata: Map<String, String>?) {
         params = parameters
         exoPlayer.playWhenReady = parameters.autoPlay?:true
         assetRepository.getAsset(parameters, object : NetworkClient.TPResponse<Asset> {

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -17,7 +17,7 @@ data class Asset(
     var liveStream: LiveStream? = null,
     val folderTree: String? = null,
     var downloadStartTimeMs: Long = 0,
-    var metadata: String? = null
+    var metadata: Map<String, String>? = null
 ) {
     fun getLocalThumbnail(context: Context): Bitmap?{
         return ImageSaver(context).load(id)

--- a/player/src/main/java/com/tpstream/player/data/AssetRepository.kt
+++ b/player/src/main/java/com/tpstream/player/data/AssetRepository.kt
@@ -54,6 +54,17 @@ internal class AssetRepository(context: Context) {
         }
     }
 
+    fun getAssetsByMetadata(metadata: Map<String, String>): LiveData<List<Asset>?> {
+        return Transformations.map(assetDao.getAllDownloadInLiveData()) { assets ->
+            assets?.filter { asset ->
+                // Check if asset's metadata contains all key-value pairs from the input metadata
+                metadata.all { (key, value) ->
+                    asset.metadata?.get(key) == value
+                }
+            }?.asDomainAssets()
+        }
+    }
+
     fun getAsset(
         params: TpInitParams,
         callback : NetworkClient.TPResponse<Asset>

--- a/player/src/main/java/com/tpstream/player/data/source/local/LocalAsset.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/local/LocalAsset.kt
@@ -22,7 +22,7 @@ internal class LocalAsset(
     var videoHeight: Int = 0,
     var folderTree: String?,
     var downloadStartTimeMs: Long = 0,
-    var metadata: String?
+    var metadata: Map<String, String>?
 )
 
 enum class DownloadStatus {

--- a/player/src/main/java/com/tpstream/player/data/source/local/TPStreamsDatabase.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/local/TPStreamsDatabase.kt
@@ -8,12 +8,14 @@ import com.tpstream.player.data.source.local.migration.RoomMigration3To4.MIGRATI
 import com.tpstream.player.data.source.local.migration.RoomMigration4To5.MIGRATION_4_5
 import com.tpstream.player.data.source.local.migration.RoomMigration5To6.MIGRATION_5_6
 import com.tpstream.player.data.source.local.migration.RoomMigration6To7.MIGRATION_6_7
+import com.tpstream.player.util.Converters
 
 @Database(
     version = 7,
     entities = [LocalAsset::class],
     exportSchema = true
 )
+@TypeConverters(Converters::class)
 internal abstract class TPStreamsDatabase : RoomDatabase() {
 
     abstract fun assetDao(): AssetDao

--- a/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
+++ b/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
@@ -17,6 +17,10 @@ class TpStreamDownloadManager(val context: Context) {
         return assetRepository.getAllDownloadsInLiveData()
     }
 
+    fun getAssetsByMetadata(metadata: Map<String, String>): LiveData<List<Asset>?> {
+        return assetRepository.getAssetsByMetadata(metadata)
+    }
+
     fun getDownloadAsset(assetId: String): LiveData<Asset?> {
         return assetRepository.getAssetInLiveData(assetId)
     }

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -172,7 +172,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     }
 
     @Deprecated("Deprecated",ReplaceWith("TpStreamPlayer.load()"),DeprecationLevel.ERROR)
-    fun load(parameters: TpInitParams, metadata: String? = null) {
+    fun load(parameters: TpInitParams, metadata: Map<String, String>? = null) {
         if (player == null) {
             throw Exception("Player is not initialized yet. `load` method should be called onInitializationSuccess")
         }

--- a/player/src/main/java/com/tpstream/player/util/Converter.kt
+++ b/player/src/main/java/com/tpstream/player/util/Converter.kt
@@ -1,0 +1,21 @@
+package com.tpstream.player.util
+
+import androidx.room.TypeConverter
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+
+class Converters {
+
+    @TypeConverter
+    fun fromMap(value: Map<String, String>?): String? {
+        return if (value == null) null else Gson().toJson(value)
+    }
+
+    @TypeConverter
+    fun toMap(value: String?): Map<String, String>? {
+        return if (value == null) null else Gson().fromJson(
+            value,
+            object : TypeToken<Map<String, String>>() {}.type
+        )
+    }
+}


### PR DESCRIPTION
- In commit 116d515, the `metadata` field was added with the datatype String.
- This commit changes the `metadata` field to a key-value pair map.
- Additionally, a filter option based on the `metadata` field has been added.