### PR TITLE
fix: Check the parameters are initialized before playing downloaded video

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -75,6 +75,10 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
             }
     }
 
+    fun isParamsInitialized(): Boolean {
+        return this::params.isInitialized
+    }
+
     override fun load(parameters: TpInitParams, metadata: Map<String, String>?) {
         params = parameters
         exoPlayer.playWhenReady = parameters.autoPlay?:true

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -179,8 +179,10 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         player?.load(parameters, metadata)
     }
 
-    override fun onDownloadsSuccess(videoId:String?) {
-        if (videoId == player?.params?.videoId){
+    override fun onDownloadsSuccess(videoId: String?) {
+        if (!this.isVisible) return
+        if (player == null) return
+        if (player?.isParamsInitialized() == true && videoId == player?.params?.videoId) {
             reloadVideo()
         }
     }


### PR DESCRIPTION
- Previously, the downloaded video would play once the download was complete, even if the fragment was not visible, causing an IllegalStateException due to a handler on a dead thread.
- In this commit, added validation to ensure the fragment is visible, the player is not null, and the `TpInitParams` object is initialized before attempting to reload the video.