### PR TITLE
fix: App crash on downloading the video on Android 14

### DIFF
--- a/player/src/main/AndroidManifest.xml
+++ b/player/src/main/AndroidManifest.xml
@@ -5,10 +5,12 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <application>
         <service android:name="com.tpstream.player.offline.VideoDownloadService"
-            android:exported="false">
+            android:exported="false"
+            android:foregroundServiceType="dataSync">
             <intent-filter>
                 <action android:name="com.google.android.exoplayer.downloadService.action.RESTART"/>
                 <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
- The app crashes when downloading a video on Android 14 because, if the app targets Android 14, it must specify appropriate foreground service types.
- This commit addresses the issue by specifying the required foreground service types. [Foreground service types are required](https://developer.android.com/about/versions/14/changes/fgs-types-required), [Data sync](https://developer.android.com/about/versions/14/changes/fgs-types-required#data-sync).