### PR TITLE
fix: Unable to Play Video from Download Activity in Sample App

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -20,8 +20,8 @@ class PlayerActivity : AppCompatActivity() {
     private val TAG = "PlayerActivity"
     private lateinit var accessToken :String
     private lateinit var videoId :String
-    private lateinit var orgCode :String
-    private lateinit var provider: TPStreamsSDK.Provider
+    private var orgCode :String = "6eafqn"
+    private var provider: TPStreamsSDK.Provider = TPStreamsSDK.Provider.TPStreams
     private var parameters : TpInitParams? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
- When opening `PlayerActivity` from `DownloadListActivity`, the `provider` and `orgCode` were not initialized, causing the app to crash due to uninitialized lateinit properties.
- In this commit, we set default values for `provider` and `orgCode` since these parameters are not required for offline videos.