### PR TITLE
fix: Handle Livestream Disconnected State

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,10 +99,10 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
-            "TPS_NON_DRM" -> {
-                accessToken = "48a481d0-7a7f-465f-9d18-86f52129430b"
-                videoId = "C65BJzhj48k"
-                orgCode = "dcek2m"
+                "TPS_NON_DRM" -> {
+                accessToken = "69ccfbf3-6813-44c5-8356-2712ca26dde7"
+                videoId = "6UcRj4qNpEb"
+                orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,11 +99,10 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
-
-                "TPS_NON_DRM" -> {
-                accessToken = "c114217a-124b-42ee-b3f0-119e155a183b"
-                videoId = "7jgUbK8prj9"
-                orgCode = "6eafqn"
+            "TPS_NON_DRM" -> {
+                accessToken = "48a481d0-7a7f-465f-9d18-86f52129430b"
+                videoId = "C65BJzhj48k"
+                orgCode = "dcek2m"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,9 +99,10 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
+
                 "TPS_NON_DRM" -> {
-                accessToken = "69ccfbf3-6813-44c5-8356-2712ca26dde7"
-                videoId = "6UcRj4qNpEb"
+                accessToken = "c114217a-124b-42ee-b3f0-119e155a183b"
+                videoId = "7jgUbK8prj9"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -40,6 +40,7 @@ data class Asset(
         val livestream = this.liveStream!!
 
         if (livestream.isDisconnected) return true
+        if (livestream.isRecording) return true
 
         return !livestream.isStreaming &&
                 !(livestream.isEnded && livestream.recordingEnabled && video.isTranscodingCompleted)
@@ -56,6 +57,7 @@ data class Asset(
             liveStream?.isNotStarted == true ->
                 "Live stream will begin soon."
             liveStream?.isDisconnected == true -> "The live stream has been disconnected. Please try again later."
+            liveStream?.isRecording == true -> "The live stream has come to an end. Stay tuned, we'll have the recording ready for you shortly."
             liveStream?.isEnded == true && liveStream.recordingEnabled && !video.isTranscodingCompleted ->
                 "Live stream has ended. Recording will be available soon."
             liveStream?.isEnded == true && !liveStream.recordingEnabled ->

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -40,7 +40,6 @@ data class Asset(
         val livestream = this.liveStream!!
 
         if (livestream.isDisconnected) return true
-        if (livestream.isRecording) return true
 
         return !livestream.isStreaming &&
                 !(livestream.isEnded && livestream.recordingEnabled && video.isTranscodingCompleted)
@@ -57,7 +56,6 @@ data class Asset(
             liveStream?.isNotStarted == true ->
                 "Live stream will begin soon."
             liveStream?.isDisconnected == true -> "The live stream has been disconnected. Please try again later."
-            liveStream?.isRecording == true -> "The live stream has come to an end. Stay tuned, we'll have the recording ready for you shortly."
             liveStream?.isEnded == true && liveStream.recordingEnabled && !video.isTranscodingCompleted ->
                 "Live stream has ended. Recording will be available soon."
             liveStream?.isEnded == true && !liveStream.recordingEnabled ->

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -55,7 +55,7 @@ data class Asset(
                 "Live stream is scheduled to start at ${liveStream.getFormattedStartTime()}"
             liveStream?.isNotStarted == true ->
                 "Live stream will begin soon."
-            liveStream?.isDisconnected == true -> "The live stream has been disconnected. Please try again later."
+            liveStream?.isDisconnected == true -> "The live stream is temporarily interrupted. We'll be back shortly."
             liveStream?.isEnded == true && liveStream.recordingEnabled && !video.isTranscodingCompleted ->
                 "Live stream has ended. Recording will be available soon."
             liveStream?.isEnded == true && !liveStream.recordingEnabled ->

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -39,6 +39,8 @@ data class Asset(
 
         val livestream = this.liveStream!!
 
+        if (livestream.isDisconnected) return true
+
         return !livestream.isStreaming &&
                 !(livestream.isEnded && livestream.recordingEnabled && video.isTranscodingCompleted)
     }
@@ -53,6 +55,7 @@ data class Asset(
                 "Live stream is scheduled to start at ${liveStream.getFormattedStartTime()}"
             liveStream?.isNotStarted == true ->
                 "Live stream will begin soon."
+            liveStream?.isDisconnected == true -> "The live stream has been disconnected. Please try again later."
             liveStream?.isEnded == true && liveStream.recordingEnabled && !video.isTranscodingCompleted ->
                 "Live stream has ended. Recording will be available soon."
             liveStream?.isEnded == true && !liveStream.recordingEnabled ->

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -6,7 +6,10 @@ import android.content.Context
 import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.os.Handler
+import android.os.Looper
 import android.util.AttributeSet
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.*
@@ -30,8 +33,13 @@ import com.tpstream.player.util.MarkerState
 import com.tpstream.player.util.NetworkClient.Companion.makeHeadRequest
 import com.tpstream.player.util.getPlayedStatusArray
 import kotlinx.coroutines.*
+import kotlinx.coroutines.NonCancellable.isActive
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlinx.coroutines.*
 import java.util.*
 import java.util.concurrent.TimeUnit
+import kotlin.math.log
 
 class TPStreamPlayerView @JvmOverloads constructor(
     context: Context,

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -30,10 +30,6 @@ import com.tpstream.player.util.MarkerState
 import com.tpstream.player.util.NetworkClient.Companion.makeHeadRequest
 import com.tpstream.player.util.getPlayedStatusArray
 import kotlinx.coroutines.*
-import kotlinx.coroutines.NonCancellable.isActive
-import java.net.HttpURLConnection
-import java.net.URL
-import kotlinx.coroutines.*
 import java.util.*
 import java.util.concurrent.TimeUnit
 

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -6,10 +6,7 @@ import android.content.Context
 import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.graphics.Color
-import android.os.Handler
-import android.os.Looper
 import android.util.AttributeSet
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.*
@@ -39,7 +36,6 @@ import java.net.URL
 import kotlinx.coroutines.*
 import java.util.*
 import java.util.concurrent.TimeUnit
-import kotlin.math.log
 
 class TPStreamPlayerView @JvmOverloads constructor(
     context: Context,
@@ -307,6 +303,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
 
     private fun showNoticeScreen(asset: Asset) {
         displayNoticeMessage(asset)
+        handleDisconnectedLiveStream(asset)
         handleNotStartedLiveStream(asset)
     }
 
@@ -314,6 +311,17 @@ class TPStreamPlayerView @JvmOverloads constructor(
         asset.getNoticeMessage()?.let {
             noticeMessage!!.text = it
             noticeScreenLayout!!.visibility = View.VISIBLE
+        }
+    }
+
+    private fun handleDisconnectedLiveStream(asset: Asset) {
+        if (asset.liveStream?.isDisconnected == true) {
+            coroutineScope.launch {
+                delay(15000)
+                withContext(Dispatchers.Main) {
+                    player.load(player.params)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
- In this commit, we handle the livestream disconnected state. If the livestream state is disconnected, we display a notice message and, in the background, make the asset detail API call at 15-second intervals to check for status changes in the livestream.