### PR TITLE
fix: Handle Livestream Not Started State

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,10 +99,9 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
-
                 "TPS_NON_DRM" -> {
-                accessToken = "c114217a-124b-42ee-b3f0-119e155a183b"
-                videoId = "7jgUbK8prj9"
+                accessToken = "30bd8416-f954-4e4a-a209-113ae66ee452"
+                videoId = "BKYbp9yN3NA"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,10 +99,10 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
-                "TPS_NON_DRM" -> {
-                accessToken = "30bd8416-f954-4e4a-a209-113ae66ee452"
-                videoId = "BKYbp9yN3NA"
-                orgCode = "6eafqn"
+            "TPS_NON_DRM" -> {
+                accessToken = "48a481d0-7a7f-465f-9d18-86f52129430b"
+                videoId = "C65BJzhj48k"
+                orgCode = "dcek2m"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,10 +99,10 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
-            "TPS_NON_DRM" -> {
-                accessToken = "48a481d0-7a7f-465f-9d18-86f52129430b"
-                videoId = "C65BJzhj48k"
-                orgCode = "dcek2m"
+                "TPS_NON_DRM" -> {
+                accessToken = "69ccfbf3-6813-44c5-8356-2712ca26dde7"
+                videoId = "6UcRj4qNpEb"
+                orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,9 +99,10 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
+
                 "TPS_NON_DRM" -> {
-                accessToken = "69ccfbf3-6813-44c5-8356-2712ca26dde7"
-                videoId = "6UcRj4qNpEb"
+                accessToken = "c114217a-124b-42ee-b3f0-119e155a183b"
+                videoId = "7jgUbK8prj9"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -39,9 +39,6 @@ data class Asset(
 
         val livestream = this.liveStream!!
 
-        if (livestream.isDisconnected) return true
-        if (livestream.isRecording) return true
-
         return !livestream.isStreaming &&
                 !(livestream.isEnded && livestream.recordingEnabled && video.isTranscodingCompleted)
     }
@@ -56,8 +53,6 @@ data class Asset(
                 "Live stream is scheduled to start at ${liveStream.getFormattedStartTime()}"
             liveStream?.isNotStarted == true ->
                 "Live stream will begin soon."
-            liveStream?.isDisconnected == true -> "The live stream has been disconnected. Please try again later."
-            liveStream?.isRecording == true -> "The live stream has come to an end. Stay tuned, we'll have the recording ready for you shortly."
             liveStream?.isEnded == true && liveStream.recordingEnabled && !video.isTranscodingCompleted ->
                 "Live stream has ended. Recording will be available soon."
             liveStream?.isEnded == true && !liveStream.recordingEnabled ->

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -40,6 +40,7 @@ data class Asset(
         val livestream = this.liveStream!!
 
         if (livestream.isDisconnected) return true
+        if (livestream.isRecording) return true
 
         return !livestream.isStreaming &&
                 !(livestream.isEnded && livestream.recordingEnabled && video.isTranscodingCompleted)
@@ -56,6 +57,7 @@ data class Asset(
             liveStream?.isNotStarted == true ->
                 "Live stream will begin soon."
             liveStream?.isDisconnected == true -> "The live stream has been disconnected. Please try again later."
+            liveStream?.isRecording == true -> "The live stream has come to an end. Stay tuned, we'll have the recording ready for you shortly."
             liveStream?.isEnded == true && liveStream.recordingEnabled && !video.isTranscodingCompleted ->
                 "Live stream has ended. Recording will be available soon."
             liveStream?.isEnded == true && !liveStream.recordingEnabled ->
@@ -104,6 +106,9 @@ data class LiveStream(
 
     val isNotStarted: Boolean
         get() = status == "Not Started"
+
+    val isRecording: Boolean
+        get() = status == "Recording"
 
     fun getFormattedStartTime(): String {
         val outputFormat = SimpleDateFormat("MMMM d, yyyy, h:mm a", Locale.getDefault())

--- a/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
@@ -69,7 +69,8 @@ internal fun getDomainLiveStream(asset: NetworkAsset): LiveStream? =
                 startTime = parseDateTime(startTime),
                 recordingEnabled = recordingEnabled,
                 enabledDRMForLive = enabledDRMForLive,
-                enabledDRMForRecording = enabledDRMForRecording
+                enabledDRMForRecording = enabledDRMForRecording,
+                noticeMessage = noticeMessage
             )
         }
     } else {

--- a/player/src/main/java/com/tpstream/player/data/source/network/NetworkAsset.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/network/NetworkAsset.kt
@@ -77,6 +77,9 @@ internal data class NetworkAsset(
         val enabledDRMForLive: Boolean,
 
         @SerializedName("enable_drm_for_recording")
-        val enabledDRMForRecording: Boolean
+        val enabledDRMForRecording: Boolean,
+
+        @SerializedName("notice_message")
+        val noticeMessage: String?
     )
 }

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -300,7 +300,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
 
     private fun showNoticeScreen(asset: Asset) {
         displayNoticeMessage(asset)
-        handleDisconnectedLiveStream(asset)
         handleNotStartedLiveStream(asset)
     }
 
@@ -308,17 +307,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
         asset.getNoticeMessage()?.let {
             noticeMessage!!.text = it
             noticeScreenLayout!!.visibility = View.VISIBLE
-        }
-    }
-
-    private fun handleDisconnectedLiveStream(asset: Asset) {
-        if (asset.liveStream?.isDisconnected == true) {
-            coroutineScope.launch {
-                delay(15000)
-                withContext(Dispatchers.Main) {
-                    player.load(player.params)
-                }
-            }
         }
     }
 

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -27,10 +27,9 @@ import com.tpstream.player.offline.DownloadTask
 import com.tpstream.player.ui.viewmodel.VideoViewModel
 import com.tpstream.player.util.ImageSaver
 import com.tpstream.player.util.MarkerState
+import com.tpstream.player.util.NetworkClient.Companion.makeHeadRequest
 import com.tpstream.player.util.getPlayedStatusArray
 import kotlinx.coroutines.*
-import okhttp3.OkHttpClient
-import okhttp3.Request
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -323,7 +322,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
     private suspend fun requestWithRetry(url: String, delay: Long) {
         while (coroutineScope.isActive) {
             try {
-                val responseCode = makeRequest(url)
+                val responseCode = makeHeadRequest(url)
                 if (responseCode == 200) {
                     withContext(Dispatchers.Main) {
                         player.load(player.params)
@@ -336,14 +335,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
             delay(delay)
         }
     }
-
-    private fun makeRequest(url: String): Int {
-        val request = Request.Builder().url(url).build()
-        OkHttpClient().newCall(request).execute().use { response ->
-            return response.code
-        }
-    }
-
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -239,6 +239,10 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
 
         override fun onPlayerError(error: PlaybackException) {
             super.onPlayerError(error)
+            if (isDisconnectedLiveStream(error)){
+                player.load(player.params)
+                return
+            }
             val errorPlayerId = SentryLogger.generatePlayerIdString()
             SentryLogger.logPlaybackException(error, player?.params, errorPlayerId)
             if (error.errorCode == PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED) {
@@ -306,6 +310,13 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
             return cause is DrmSessionException || cause is MediaCodec.CryptoException || cause is MediaDrmCallbackException
         }
 
+    }
+
+    private fun isDisconnectedLiveStream(error: PlaybackException): Boolean {
+        player.asset?.liveStream?.let {
+            return it.isNotEnded && error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED
+        }
+        return false
     }
 
     private fun showErrorMessage(message: String) {

--- a/player/src/main/java/com/tpstream/player/util/NetworkClient.kt
+++ b/player/src/main/java/com/tpstream/player/util/NetworkClient.kt
@@ -10,6 +10,13 @@ import java.net.URL
 internal class NetworkClient<T : Any>(val klass: Class<T>) {
     companion object {
         inline operator fun <reified T : Any>invoke() = NetworkClient(T::class.java)
+
+        fun makeHeadRequest(url: String): Int {
+            val request = Request.Builder().head().url(url).build()
+            OkHttpClient().newCall(request).execute().use { response ->
+                return response.code
+            }
+        }
     }
 
     private var client: OkHttpClient = OkHttpClient();
@@ -75,3 +82,4 @@ internal class NetworkClient<T : Any>(val klass: Class<T>) {
         fun onFailure(exception: TPException)
     }
 }
+


### PR DESCRIPTION
- In this commit, we handle the 'Not Started' state for livestreams. If the livestream state is 'Not Started', we display a notice message and, in the background, make requests for the m3u8 URL at 10-second intervals until the request succeeds. Once successful, we reload the player to start the livestream.