### PR TITLE
refactor: Remove player from VideoDownloadRequestCreationHandler

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -43,7 +43,8 @@ internal class DownloadResolutionSelectionSheet(
         videoDownloadRequestCreateHandler =
             VideoDownloadRequestCreationHandler(
                 requireContext(),
-                player
+                asset = asset!!,
+                params = player.params
             )
         videoDownloadRequestCreateHandler.listener = this
     }


### PR DESCRIPTION
- Previously, the player was used inside the VideoDownloadRequestCreationHandler, preventing the exposure of the download start API. In this commit, the player has been removed, and `Asset` and `TpInitParams` have been added instead.