### PR TITLE
refactor: Remove player from DownloadResolutionSelectionSheet

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -2,7 +2,6 @@ package com.tpstream.player.ui
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -179,7 +178,6 @@ internal class DownloadResolutionSelectionSheet(
         private fun getVideoSize(trackInfo: TrackInfo): String {
             val mbps = (((trackInfo.format.bitrate).toFloat() / 8f / 1024f) / 1024f)
             val videoLengthInSecond = asset.video.duration
-            Log.d("TAG", "getVideoSize: $videoLengthInSecond")
             return "${((mbps * videoLengthInSecond)).roundToInt()} MB"            //Mbps
         }
 

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -121,8 +121,8 @@ class TPStreamPlayerView @JvmOverloads constructor(
                     player.asset?.video?.url!!
                 )
                 val downloadResolutionSelectionSheet = DownloadResolutionSelectionSheet(
-                    player,
-                    player.getTrackSelectionParameters(),
+                    player.asset!!,
+                    player.params
                 )
                 downloadResolutionSelectionSheet.show((context as FragmentActivity).supportFragmentManager, "DownloadSelectionSheet")
                 downloadResolutionSelectionSheet.setOnSubmitListener { downloadRequest, asset ->


### PR DESCRIPTION
- Previously, the player was used inside the DownloadResolutionSelectionSheet, preventing the exposure of the download start API. In this commit, the player has been removed, and `Asset` and `TpInitParams` have been added instead.