### PR TITLE
fix: Add API to start download

### DIFF
--- a/app/src/main/java/com/tpstream/app/MainActivity.kt
+++ b/app/src/main/java/com/tpstream/app/MainActivity.kt
@@ -4,6 +4,9 @@ import android.content.Intent
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
+import com.tpstream.player.TPStreamsSDK
+import com.tpstream.player.TpInitParams
+import com.tpstream.player.offline.TpStreamDownloadManager
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,6 +47,15 @@ class MainActivity : AppCompatActivity() {
     fun downloadButton(view: View) {
         val myIntent = Intent(this, DownloadListActivity::class.java)
         startActivity(myIntent)
+    }
+
+    fun downloadDRMVideo(view: View) {
+        TPStreamsSDK.initialize(TPStreamsSDK.Provider.TPStreams, "6eafqn")
+        val parameters = TpInitParams.Builder()
+            .setVideoId("6suEBPy7EG4")
+            .setAccessToken("ab70caed-6168-497f-89c1-1e308da2c9aa")
+            .build()
+        TpStreamDownloadManager(applicationContext).startDownload(this,parameters)
     }
 
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -111,6 +111,15 @@
             android:onClick="downloadButton"
             android:text="Videos" />
 
+        <Button
+            android:id="@+id/button7"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginTop="16dp"
+            android:onClick="downloadDRMVideo"
+            android:text="Download Sample Video" />
+
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -52,3 +52,13 @@ internal fun PlaybackException.getErrorMessage(playerId: String): String {
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Error code: 5100. Player Id: $playerId"
     }
 }
+
+internal fun TPException.getErrorMessageForDownload(): String {
+    return when {
+        this.isNetworkError() -> "Please check your connection and try again"
+        this.response?.code == 404 -> "The video is not available. Please try another one."
+        this.isUnauthenticated() -> "Sorry, you don't have permission to download this video"
+        this.isServerError() -> "We're sorry, but there's an issue on our server. Please try again later."
+        else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue."
+    }
+}

--- a/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
+++ b/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
@@ -1,10 +1,17 @@
 package com.tpstream.player.offline
 
 import android.content.Context
+import android.widget.Toast
+import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.LiveData
+import com.tpstream.player.*
+import com.tpstream.player.EncryptionKeyRepository
+import com.tpstream.player.constants.getErrorMessageForDownload
 import com.tpstream.player.util.ImageSaver
 import com.tpstream.player.data.Asset
 import com.tpstream.player.data.AssetRepository
+import com.tpstream.player.ui.DownloadResolutionSelectionSheet
+import com.tpstream.player.util.NetworkClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -23,6 +30,85 @@ class TpStreamDownloadManager(val context: Context) {
 
     fun getDownloadAsset(assetId: String): LiveData<Asset?> {
         return assetRepository.getAssetInLiveData(assetId)
+    }
+
+    fun startDownload(fragmentActivity: FragmentActivity, params: TpInitParams) {
+        showDownloadSelectionSheet(fragmentActivity, params, null)
+    }
+
+    fun startDownload(fragmentActivity: FragmentActivity, player: TpStreamPlayer) {
+        val playerImpl = player as TpStreamPlayerImpl
+        showDownloadSelectionSheet(fragmentActivity, playerImpl.params, playerImpl.asset)
+    }
+
+    private fun showDownloadSelectionSheet(
+        fragmentActivity: FragmentActivity,
+        params: TpInitParams,
+        asset: Asset?
+    ) {
+        val downloadResolutionSelectionSheet = DownloadResolutionSelectionSheet()
+        downloadResolutionSelectionSheet.show(
+            fragmentActivity.supportFragmentManager,
+            "DownloadSelectionSheet"
+        )
+
+        val assetToUse = asset ?: run {
+            // Fetch asset if not provided
+            var fetchedAsset: Asset? = null
+            assetRepository.getAsset(params, object : NetworkClient.TPResponse<Asset> {
+                override fun onSuccess(result: Asset) {
+                    fetchedAsset = result
+                    onFetchAssetSuccess(result, params, downloadResolutionSelectionSheet)
+                }
+
+                override fun onFailure(exception: TPException) {
+                    onFetchAssetFailure(exception, downloadResolutionSelectionSheet)
+                }
+            })
+            fetchedAsset
+        }
+
+        assetToUse?.let {
+            onFetchAssetSuccess(it, params, downloadResolutionSelectionSheet)
+        }
+    }
+
+    private fun onFetchAssetSuccess(
+        asset: Asset,
+        params: TpInitParams,
+        downloadResolutionSelectionSheet: DownloadResolutionSelectionSheet
+    ) {
+        EncryptionKeyRepository(context).fetchAndStore(
+            params,
+            asset.video.url
+        )
+        downloadResolutionSelectionSheet.add(context, asset, params)
+        downloadResolutionSelectionSheet.setOnSubmitListener { downloadRequest, asset ->
+            DownloadTask(context).start(downloadRequest)
+            asset?.id = params.videoId!!
+            asset?.downloadStartTimeMs = System.currentTimeMillis()
+            ImageSaver(context).save(
+                asset?.thumbnail!!,
+                asset.id
+            )
+            CoroutineScope(Dispatchers.IO).launch {
+                assetRepository.insert(asset)
+            }
+        }
+    }
+
+    private fun onFetchAssetFailure(
+        exception: TPException,
+        downloadResolutionSelectionSheet: DownloadResolutionSelectionSheet
+    ) {
+        CoroutineScope(Dispatchers.Main).launch {
+            downloadResolutionSelectionSheet.dismiss()
+            Toast.makeText(
+                context,
+                exception.getErrorMessageForDownload(),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
     }
 
     fun pauseDownload(asset: Asset) {

--- a/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
+++ b/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
@@ -82,7 +82,7 @@ class TpStreamDownloadManager(val context: Context) {
             params,
             asset.video.url
         )
-        downloadResolutionSelectionSheet.add(context, asset, params)
+        downloadResolutionSelectionSheet.initializeVideoDownloadRequestCreateHandler(context, asset, params)
         downloadResolutionSelectionSheet.setOnSubmitListener { downloadRequest, asset ->
             DownloadTask(context).start(downloadRequest)
             asset?.id = params.videoId!!

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -23,29 +23,17 @@ import kotlin.math.roundToInt
 
 internal typealias OnSubmitListener = (DownloadRequest, Asset?) -> Unit
 
-internal class DownloadResolutionSelectionSheet(
-    private val asset: Asset,
-    private val params: TpInitParams,
-) : BottomSheetDialogFragment(), VideoDownloadRequestCreationHandler.Listener {
+internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), VideoDownloadRequestCreationHandler.Listener {
 
     private var _binding: TpDownloadTrackSelectionDialogBinding? = null
     private val binding get() = _binding!!
     private lateinit var videoDownloadRequestCreateHandler: VideoDownloadRequestCreationHandler
     private lateinit var overrides: MutableMap<TrackGroup, TrackSelectionOverride>
+    private lateinit var asset: Asset
+    private lateinit var params: TpInitParams
     var isResolutionSelected = false
     private var trackGroups: MutableList<TracksGroup> = mutableListOf()
     private var onSubmitListener: OnSubmitListener? = null
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        videoDownloadRequestCreateHandler =
-            VideoDownloadRequestCreationHandler(
-                requireContext(),
-                asset = asset,
-                params = params
-            )
-        videoDownloadRequestCreateHandler.listener = this
-    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -59,6 +47,18 @@ internal class DownloadResolutionSelectionSheet(
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    fun add(context: Context, asset: Asset, params: TpInitParams) {
+        this.asset = asset
+        this.params = params
+        videoDownloadRequestCreateHandler =
+            VideoDownloadRequestCreationHandler(
+                context,
+                asset = asset,
+                params = params
+            )
+        videoDownloadRequestCreateHandler.listener = this
     }
 
     override fun onDownloadRequestHandlerPrepared(isPrepared: Boolean, downloadHelper: DownloadHelper) {

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -49,7 +49,7 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
         _binding = null
     }
 
-    fun add(context: Context, asset: Asset, params: TpInitParams) {
+    fun initializeVideoDownloadRequestCreateHandler(context: Context, asset: Asset, params: TpInitParams) {
         this.asset = asset
         this.params = params
         videoDownloadRequestCreateHandler =

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -23,9 +23,8 @@ import com.tpstream.player.data.AssetRepository
 import com.tpstream.player.data.source.local.DownloadStatus
 import com.tpstream.player.databinding.TpStreamPlayerViewBinding
 import com.tpstream.player.constants.PlaybackSpeed
-import com.tpstream.player.offline.DownloadTask
+import com.tpstream.player.offline.TpStreamDownloadManager
 import com.tpstream.player.ui.viewmodel.VideoViewModel
-import com.tpstream.player.util.ImageSaver
 import com.tpstream.player.util.MarkerState
 import com.tpstream.player.util.NetworkClient.Companion.makeHeadRequest
 import com.tpstream.player.util.getPlayedStatusArray
@@ -116,25 +115,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
                 Toast.makeText(context, "Downloading", Toast.LENGTH_SHORT).show()
             }
             else -> {
-                EncryptionKeyRepository(context).fetchAndStore(
-                    player.params,
-                    player.asset?.video?.url!!
-                )
-                val downloadResolutionSelectionSheet = DownloadResolutionSelectionSheet(
-                    player.asset!!,
-                    player.params
-                )
-                downloadResolutionSelectionSheet.show((context as FragmentActivity).supportFragmentManager, "DownloadSelectionSheet")
-                downloadResolutionSelectionSheet.setOnSubmitListener { downloadRequest, asset ->
-                    DownloadTask(context).start(downloadRequest)
-                    asset?.id = player.params.videoId!!
-                    asset?.downloadStartTimeMs = System.currentTimeMillis()
-                    ImageSaver(context).save(
-                        asset?.thumbnail!!,
-                        asset.id
-                    )
-                    videoViewModel.insert(asset)
-                }
+                TpStreamDownloadManager(context).startDownload((context as FragmentActivity),player)
             }
         }
     }


### PR DESCRIPTION
- In this commit, we added the `startDownload()` method in `TpStreamDownloadManager`. This allows for video downloads without the player, as well as downloads with the player. Additionally, we removed the existing download logic from `TpstreamPlayerView`.