### PR TITLE
fix: NullPointerException when Updating the Download Button Image

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -271,7 +271,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
         }
     }
 
-
     private fun updatePlayerViewForLive(){
         val durationView: TextView = playerView.findViewById(ExoplayerResourceID.exo_duration)
         val durationSeparator: TextView = playerView.findViewById(R.id.exo_separator)

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -249,6 +249,8 @@ class TPStreamPlayerView @JvmOverloads constructor(
     }
 
     private fun updateDownloadButtonImage(){
+        if (player.asset == null) return
+        if (player.asset?.id == null) return
         videoViewModel.get(player.asset?.id!!).observe(context as FragmentActivity) { asset ->
             downloadState = when (asset?.video?.downloadState) {
                 DownloadStatus.DOWNLOADING ->{

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -255,11 +255,11 @@ class TPStreamPlayerView @JvmOverloads constructor(
 
         videoViewModel.get(assetId).observe(fragmentActivity) { asset ->
             downloadState = when (asset?.video?.downloadState) {
-                DownloadStatus.DOWNLOADING -> {
+                DownloadStatus.DOWNLOADING ->{
                     downloadButton?.setImageResource(R.drawable.ic_baseline_downloading_24)
                     DownloadStatus.DOWNLOADING
                 }
-                DownloadStatus.COMPLETE -> {
+                DownloadStatus.COMPLETE ->{
                     downloadButton?.setImageResource(R.drawable.ic_baseline_file_download_done_24)
                     DownloadStatus.COMPLETE
                 }

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -251,26 +251,26 @@ class TPStreamPlayerView @JvmOverloads constructor(
     private fun updateDownloadButtonImage() {
         val assetId = player.asset?.id
         val fragmentActivity = context as? FragmentActivity
+        if (assetId == null || fragmentActivity == null || downloadButton == null) return
 
-        if (assetId != null && fragmentActivity != null && downloadButton != null) {
-            videoViewModel.get(assetId).observe(fragmentActivity) { asset ->
-                downloadState = when (asset?.video?.downloadState) {
-                    DownloadStatus.DOWNLOADING -> {
-                        downloadButton?.setImageResource(R.drawable.ic_baseline_downloading_24)
-                        DownloadStatus.DOWNLOADING
-                    }
-                    DownloadStatus.COMPLETE -> {
-                        downloadButton?.setImageResource(R.drawable.ic_baseline_file_download_done_24)
-                        DownloadStatus.COMPLETE
-                    }
-                    else -> {
-                        downloadButton?.setImageResource(R.drawable.ic_baseline_download_for_offline_24)
-                        null
-                    }
+        videoViewModel.get(assetId).observe(fragmentActivity) { asset ->
+            downloadState = when (asset?.video?.downloadState) {
+                DownloadStatus.DOWNLOADING -> {
+                    downloadButton?.setImageResource(R.drawable.ic_baseline_downloading_24)
+                    DownloadStatus.DOWNLOADING
+                }
+                DownloadStatus.COMPLETE -> {
+                    downloadButton?.setImageResource(R.drawable.ic_baseline_file_download_done_24)
+                    DownloadStatus.COMPLETE
+                }
+                else -> {
+                    downloadButton?.setImageResource(R.drawable.ic_baseline_download_for_offline_24)
+                    null
                 }
             }
         }
     }
+
 
     private fun updatePlayerViewForLive(){
         val durationView: TextView = playerView.findViewById(ExoplayerResourceID.exo_duration)

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -248,22 +248,25 @@ class TPStreamPlayerView @JvmOverloads constructor(
         }
     }
 
-    private fun updateDownloadButtonImage(){
-        if (player.asset == null) return
-        if (player.asset?.id == null) return
-        videoViewModel.get(player.asset?.id!!).observe(context as FragmentActivity) { asset ->
-            downloadState = when (asset?.video?.downloadState) {
-                DownloadStatus.DOWNLOADING ->{
-                    downloadButton?.setImageResource(R.drawable.ic_baseline_downloading_24)
-                    DownloadStatus.DOWNLOADING
-                }
-                DownloadStatus.COMPLETE ->{
-                    downloadButton?.setImageResource(R.drawable.ic_baseline_file_download_done_24)
-                    DownloadStatus.COMPLETE
-                }
-                else -> {
-                    downloadButton?.setImageResource(R.drawable.ic_baseline_download_for_offline_24)
-                    null
+    private fun updateDownloadButtonImage() {
+        val assetId = player.asset?.id
+        val fragmentActivity = context as? FragmentActivity
+
+        if (assetId != null && fragmentActivity != null && downloadButton != null) {
+            videoViewModel.get(assetId).observe(fragmentActivity) { asset ->
+                downloadState = when (asset?.video?.downloadState) {
+                    DownloadStatus.DOWNLOADING -> {
+                        downloadButton?.setImageResource(R.drawable.ic_baseline_downloading_24)
+                        DownloadStatus.DOWNLOADING
+                    }
+                    DownloadStatus.COMPLETE -> {
+                        downloadButton?.setImageResource(R.drawable.ic_baseline_file_download_done_24)
+                        DownloadStatus.COMPLETE
+                    }
+                    else -> {
+                        downloadButton?.setImageResource(R.drawable.ic_baseline_download_for_offline_24)
+                        null
+                    }
                 }
             }
         }


### PR DESCRIPTION
- In some cases, while updating the download button image, a NullPointerException occurred. In this commit, we added null checks for the `fragmentActivity`, `assetId`, and `downloadButton` to prevent this issue.