### PR TITLE
 fix: Set autoPlay as default true

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpInitParams.kt
+++ b/player/src/main/java/com/tpstream/player/TpInitParams.kt
@@ -5,7 +5,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class TpInitParams (
-    var autoPlay: Boolean = false,
+    var autoPlay: Boolean = true,
     var accessToken: String? = null,
     var videoId: String? = null,
     var isDownloadEnabled: Boolean = false,
@@ -13,7 +13,7 @@ data class TpInitParams (
 ): Parcelable {
     
     class Builder {
-        private var autoPlay: Boolean = false
+        private var autoPlay: Boolean = true
         private var accessToken: String? = null
         private var videoId: String? = null
         private var isDownloadEnabled: Boolean = false

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -81,7 +81,7 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
 
     override fun load(parameters: TpInitParams, metadata: Map<String, String>?) {
         params = parameters
-        exoPlayer.playWhenReady = parameters.autoPlay?:true
+        exoPlayer.playWhenReady = parameters.autoPlay
         assetRepository.getAsset(parameters, object : NetworkClient.TPResponse<Asset> {
             override fun onSuccess(result: Asset) {
                 asset = result


### PR DESCRIPTION
- In this commit bcee6aa, we made `autoPlay` a non-nullable value and set the default to false, but it needs to be true.
- In this commit, we set `autoPlay` as default true.