### PR TITLE
fix: Download button not appearing for completed livestreams

### DIFF
--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -31,6 +31,11 @@ data class Asset(
         }
     }
 
+    val isDownloadable: Boolean
+    get() {
+        return video != null && video.isTranscodingCompleted
+    }
+
     val isLiveStream: Boolean
         get() = type == "livestream"
 

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -186,7 +186,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
     private fun initializeLoadCompleteListener() {
         player.setLoadCompleteListener {
             (context as FragmentActivity).runOnUiThread {
-                if (player.params.isDownloadEnabled && !it.isLiveStream) {
+                if (player.params.isDownloadEnabled && it.isDownloadable) {
                     downloadButton?.isVisible = true
                     updateDownloadButtonImage()
                 }


### PR DESCRIPTION
- Previously, the download button was not displayed for live streams. We have now added a check to ensure that the video object in the Asset model is not null and that the transcoding is complete. If these conditions are met, the download button will be shown.