### PR TITLE
refactor: Show user understandable error message

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -281,7 +281,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         private fun fetchDRMLicence(error: PlaybackException){
             val errorPlayerId = SentryLogger.generatePlayerIdString()
             if (!InternetConnectivityChecker.isNetworkAvailable(requireContext())) {
-                showErrorMessage(TPException.networkError(IOException()).getErrorMessage(errorPlayerId))
+                showErrorMessage(getString(R.string.no_internet_to_sync_license))
                 return
             }
             val url = player?.asset?.video?.url
@@ -303,7 +303,9 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         }
 
         override fun onLicenseFetchFailure() {
-            showErrorMessage(getString(R.string.license_error))
+            CoroutineScope(Dispatchers.Main).launch {
+                showErrorMessage(getString(R.string.license_error))
+            }
         }
 
         private fun isDRMException(cause: Throwable): Boolean {

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -303,9 +303,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         }
 
         override fun onLicenseFetchFailure() {
-            CoroutineScope(Dispatchers.Main).launch {
-                showErrorMessage(getString(R.string.license_error))
-            }
+            showErrorMessage(getString(R.string.license_error))
         }
 
         private fun isDRMException(cause: Throwable): Boolean {

--- a/player/src/main/res/values/strings.xml
+++ b/player/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
 
     <!-- Error message -->
     <string name="syncing_video">Please wait… We are syncing video</string>
-    <string name="no_internet_to_sync_license">Please turn on internet to fetch video license</string>
+    <string name="no_internet_to_sync_license">Playback license has expired. Please connect to the internet to renew the playback license.</string>
     <string name="license_error">Error in fetching video license. Please try again</string>
     <string name="license_request_failed">Couldn\'t fetch decryption key. Please try again</string>
     


### PR DESCRIPTION
- In this commit, we rephrased the internet error message for renewing the playback license to enhance understanding.