### PR TITLE
refactor: Replace `DownloadHelper` parameter with `Format` in `fetchLicense()`

### DIFF
--- a/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
+++ b/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
@@ -96,7 +96,7 @@ internal object OfflineDRMLicenseHelper {
     fun fetchLicense(
         context: Context,
         tpInitParams: TpInitParams,
-        downloadHelper: DownloadHelper,
+        format: Format,
         callback: DRMLicenseFetchCallback
     ) {
         val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken)
@@ -105,10 +105,9 @@ internal object OfflineDRMLicenseHelper {
             VideoDownloadManager.invoke(context).getHttpDataSourceFactory(),
             DrmSessionEventListenerEventDispatcher()
         )
-        val format = VideoPlayerUtil.getAudioOrVideoInfoWithDrmInitData(downloadHelper)
         CoroutineScope(Dispatchers.IO).launch {
             try {
-                val keySetId = offlineLicenseHelper.downloadLicense(format!!)
+                val keySetId = offlineLicenseHelper.downloadLicense(format)
                 callback.onLicenseFetchSuccess(keySetId)
             } catch (e: DrmSessionException) {
                 callback.onLicenseFetchFailure()

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -57,7 +57,7 @@ internal class VideoDownloadRequestCreationHandler(
         val isDRMProtectedVideo = videoOrAudioData != null
         if (isDRMProtectedVideo) {
             if (hasDRMSchemaData(videoOrAudioData!!.drmInitData!!)) {
-                OfflineDRMLicenseHelper.fetchLicense(context, params, downloadHelper, this)
+                OfflineDRMLicenseHelper.fetchLicense(context, params, videoOrAudioData, this)
             } else {
                 Toast.makeText(
                     context,


### PR DESCRIPTION
- In this commit, we replaced the `DownloadHelper` parameter with `Format` in `fetchLicense()` to improve the reusability of the `fetchLicense()` function.