### PR TITLE
fix: Add onAccessTokenExpired callback in TPStreamPlayerListener

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -42,6 +42,11 @@ class PlayerActivity : AppCompatActivity() {
                         Log.d(TAG, "onPlaybackStateChanged: $playbackState")
                     }
 
+                    override fun onAccessTokenExpired(videoId: String?, callback: (String) -> Unit) {
+                        val newAccessToken = getAccessToken(videoId!!)
+                        callback.invoke(newAccessToken)
+                    }
+
                     override fun onMarkerCallback(timesInSeconds: Long) {
                         Toast.makeText(this@PlayerActivity,"$timesInSeconds",Toast.LENGTH_SHORT).show()
                     }
@@ -94,7 +99,7 @@ class PlayerActivity : AppCompatActivity() {
                 provider = TPStreamsSDK.Provider.TestPress
             }
             "TPS_DRM" -> {
-                accessToken = "ab70caed-6168-497f-89c1-1e308da2c9aa"
+                accessToken = "ab70caed-6168-497f-89c1-1e308da2c9a"
                 videoId = "6suEBPy7EG4"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
@@ -118,6 +123,17 @@ class PlayerActivity : AppCompatActivity() {
         }
         findViewById<Button>(R.id.enter_full_screen).setOnClickListener {
             playerFragment.showFullScreen()
+        }
+    }
+
+    fun getAccessToken(videoId: String): String {
+        return when (videoId) {
+            "ATJfRdHIUC9" -> "a4c04ca8-9c0e-4c9c-a889-bd3bf8ea586a"
+            "ZZb3S5OB3nY" -> "5f6355d0-62ac-4bfd-98ca-4a1e9a2857e3"
+            "z1TLpfuZzXh" -> "5c49285b-0557-4cef-b214-66034d0b77c3"
+            "6suEBPy7EG4" -> "ab70caed-6168-497f-89c1-1e308da2c9a"
+            "C65BJzhj48k" -> "48a481d0-7a7f-465f-9d18-86f52129430b"
+            else -> ""
         }
     }
 

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -42,8 +42,8 @@ class PlayerActivity : AppCompatActivity() {
                         Log.d(TAG, "onPlaybackStateChanged: $playbackState")
                     }
 
-                    override fun onAccessTokenExpired(videoId: String?, callback: (String) -> Unit) {
-                        val newAccessToken = getAccessToken(videoId!!)
+                    override fun onAccessTokenExpired(videoId: String, callback: (String) -> Unit) {
+                        val newAccessToken = getAccessToken(videoId)
                         callback.invoke(newAccessToken)
                     }
 

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -99,7 +99,7 @@ class PlayerActivity : AppCompatActivity() {
                 provider = TPStreamsSDK.Provider.TestPress
             }
             "TPS_DRM" -> {
-                accessToken = "ab70caed-6168-497f-89c1-1e308da2c9a"
+                accessToken = "ab70caed-6168-497f-89c1-1e308da2c9aa"
                 videoId = "6suEBPy7EG4"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams

--- a/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
@@ -19,7 +19,7 @@ interface TPStreamPlayerListener {
     fun onPlayerError(playbackError: PlaybackError) {}
     fun onMarkerCallback(timesInSeconds: Long) {}
     fun onFullScreenChanged(isFullScreen: Boolean) {}
-    fun onAccessTokenExpired(videoId: String?, callback: (String) -> Unit) {
+    fun onAccessTokenExpired(videoId: String, callback: (String) -> Unit) {
         callback.invoke("")
     }
 }

--- a/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
@@ -1,6 +1,5 @@
 package com.tpstream.player
 
-import android.util.Log
 import com.tpstream.player.constants.PlaybackError
 
 interface TPStreamPlayerListener {

--- a/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
@@ -1,5 +1,6 @@
 package com.tpstream.player
 
+import android.util.Log
 import com.tpstream.player.constants.PlaybackError
 
 interface TPStreamPlayerListener {
@@ -18,4 +19,7 @@ interface TPStreamPlayerListener {
     fun onPlayerError(playbackError: PlaybackError) {}
     fun onMarkerCallback(timesInSeconds: Long) {}
     fun onFullScreenChanged(isFullScreen: Boolean) {}
+    fun onAccessTokenExpired(videoId: String?, callback: (String) -> Unit) {
+        callback.invoke("")
+    }
 }

--- a/player/src/main/java/com/tpstream/player/TpInitParams.kt
+++ b/player/src/main/java/com/tpstream/player/TpInitParams.kt
@@ -39,6 +39,10 @@ data class TpInitParams (
         }
     }
 
+    internal fun setNewAccessToken(newAccessToken: String){
+        this.accessToken = newAccessToken
+    }
+
     val startPositionInMilliSecs: Long
         get() = startAt * 1000L
 

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -332,7 +332,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
             requireActivity().runOnUiThread {
                 val errorPlayerId = SentryLogger.generatePlayerIdString()
                 if (exception.isUnauthenticated()) {
-                    player?._listener?.onAccessTokenExpired(parameters.videoId) { newAccessToken ->
+                    player?._listener?.onAccessTokenExpired(parameters.videoId!!) { newAccessToken ->
                         if (newAccessToken.isNotEmpty()) {
                             parameters.setNewAccessToken(newAccessToken)
                             player?.load(parameters)


### PR DESCRIPTION
- Previously, when fetching the asset with an invalid access token, we displayed an error message and called onPlayerError.
- In this commit, we added onAccessTokenExpired with a function type parameter. Now, if the access token is invalid, we call onAccessTokenExpired first. This allows us to obtain a new access token and reload the player. If onAccessTokenExpired is not overridden, the previous behavior will occur: we display the error and call onPlayerError with
- INVALID_ACCESS_TOKEN_FOR_ASSETS.