### PR TITLE
fix: Add onAccessTokenExpired callback

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -131,7 +131,7 @@ class PlayerActivity : AppCompatActivity() {
             "ATJfRdHIUC9" -> "a4c04ca8-9c0e-4c9c-a889-bd3bf8ea586a"
             "ZZb3S5OB3nY" -> "5f6355d0-62ac-4bfd-98ca-4a1e9a2857e3"
             "z1TLpfuZzXh" -> "5c49285b-0557-4cef-b214-66034d0b77c3"
-            "6suEBPy7EG4" -> "ab70caed-6168-497f-89c1-1e308da2c9a"
+            "6suEBPy7EG4" -> "ab70caed-6168-497f-89c1-1e308da2c9aa"
             "C65BJzhj48k" -> "48a481d0-7a7f-465f-9d18-86f52129430b"
             else -> ""
         }

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -110,7 +110,7 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
         }
     }
 
-    private fun playVideoInUIThread(url: String,startPosition: Long = 0) {
+    fun playVideoInUIThread(url: String,startPosition: Long = 0) {
         Handler(Looper.getMainLooper()).post {
             playVideo(url, startPosition)
         }

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -250,7 +250,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
                 player?._listener?.onAccessTokenExpired(player?.params?.videoId!!){ newAccessToken ->
                     if (newAccessToken.isNotEmpty()) {
                         player?.params?.setNewAccessToken(newAccessToken)
-                        player?.playVideoInUIThread(player.asset?.video?.url!!, player.params.startPositionInMilliSecs)
+                        player?.playVideoInUIThread(player.asset?.video?.url!!, player.getCurrentTime())
                     } else {
                         showErrorMessage(error.getErrorMessage(errorPlayerId))
                         player?._listener?.onPlayerError(error.toError())

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -247,8 +247,15 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
             val errorPlayerId = SentryLogger.generatePlayerIdString()
             SentryLogger.logPlaybackException(error, player?.params, errorPlayerId)
             if (error.errorCode == PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED) {
-                showErrorMessage(error.getErrorMessage(errorPlayerId))
-                player?._listener?.onPlayerError(error.toError())
+                player?._listener?.onAccessTokenExpired(player?.params?.videoId!!){ newAccessToken ->
+                    if (newAccessToken.isNotEmpty()) {
+                        player?.params?.setNewAccessToken(newAccessToken)
+                        player?.playVideoInUIThread(player.asset?.video?.url!!, player.params.startPositionInMilliSecs)
+                    } else {
+                        showErrorMessage(error.getErrorMessage(errorPlayerId))
+                        player?._listener?.onPlayerError(error.toError())
+                    }
+                }
                 return
             }
             if (isDRMException(error.cause!!)) {


### PR DESCRIPTION
- In this commit, we added the option to call onAccessTokenExpired when a DRM license fetching error occurs.
- If the DRM license is expired, we update the DRM license URL and play the ExoPlayer without fetching the asset.