### PR TITLE
fix: App crash when renew offline drm licence

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpInitParams.kt
+++ b/player/src/main/java/com/tpstream/player/TpInitParams.kt
@@ -62,7 +62,7 @@ data class TpInitParams (
                 videoId = videoId,
                 isDownloadEnabled = true,
                 autoPlay = true,
-                accessToken = "offlineVideo"
+                accessToken = "dummyAccessToken"
             )
         }
     }

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -109,7 +109,7 @@ internal class VideoDownloadRequestCreationHandler(
         }
     }
 
-    override fun onLicenseFetchFailure() {
+    override fun onLicenseFetchFailure(error: DrmSessionException) {
         CoroutineScope(Dispatchers.Main).launch {
             Toast.makeText(
                 context,

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -300,6 +300,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         }
 
         override fun onLicenseFetchSuccess(keySetId: ByteArray) {
+            if (!this@TpStreamPlayerFragment.isAdded) return
             OfflineDRMLicenseHelper.replaceKeysInExistingDownloadedVideo(
                 player.asset?.video?.url!!,
                 requireContext(),
@@ -312,6 +313,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         }
 
         override fun onLicenseFetchFailure(error: DrmSessionException) {
+            if (!this@TpStreamPlayerFragment.isAdded) return
             requireActivity().runOnUiThread{
                 player._listener?.onAccessTokenExpired(player.params.videoId!!){ newAccessToken ->
                     if (newAccessToken.isNotEmpty()) {

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -10,13 +10,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
 import androidx.core.content.ContextCompat
-import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import com.tpstream.player.*
 import com.tpstream.player.Util
-import com.tpstream.player.constants.PlaybackError
 import com.tpstream.player.databinding.FragmentTpStreamPlayerBinding
 import com.tpstream.player.constants.getErrorMessage
 import com.tpstream.player.constants.toError
@@ -26,7 +22,6 @@ import com.tpstream.player.util.SentryLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import java.io.IOException
 
 class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private val _playbackStateListener: PlayerListener = InternalPlayerListener()
@@ -292,26 +287,44 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
                 showErrorMessage(getString(R.string.no_internet_to_sync_license))
                 return
             }
-            val url = player?.asset?.video?.url
-            val downloadTask = DownloadTask(requireContext())
-            drmLicenseRetries += 1
-            if (drmLicenseRetries < 2 && downloadTask.isDownloaded(url!!)) {
-                OfflineDRMLicenseHelper.renewLicense(url, player?.params!!, activity!!, this)
-                showErrorMessage(getString(R.string.syncing_video))
-            } else {
-                showErrorMessage(error.getErrorMessage(errorPlayerId))
+            player._listener?.onAccessTokenExpired(player.params.videoId!!){ newAccessToken ->
+                if (newAccessToken.isNotEmpty()) {
+                    player.params.setNewAccessToken(newAccessToken)
+                    OfflineDRMLicenseHelper.renewLicense(player.asset?.video?.url!!, player.params, activity!!, this)
+                    showErrorMessage(getString(R.string.syncing_video))
+                } else {
+                    SentryLogger.logPlaybackException(error, player?.params, errorPlayerId)
+                    showErrorMessage(getString(R.string.license_error)+"\n Player Id: $errorPlayerId")
+                }
             }
         }
 
         override fun onLicenseFetchSuccess(keySetId: ByteArray) {
+            OfflineDRMLicenseHelper.replaceKeysInExistingDownloadedVideo(
+                player.asset?.video?.url!!,
+                requireContext(),
+                keySetId
+            )
             CoroutineScope(Dispatchers.Main).launch {
                 reloadVideo()
                 drmLicenseRetries = 0
             }
         }
 
-        override fun onLicenseFetchFailure() {
-            showErrorMessage(getString(R.string.license_error))
+        override fun onLicenseFetchFailure(error: DrmSessionException) {
+            requireActivity().runOnUiThread{
+                player._listener?.onAccessTokenExpired(player.params.videoId!!){ newAccessToken ->
+                    if (newAccessToken.isNotEmpty()) {
+                        player.params.setNewAccessToken(newAccessToken)
+                        OfflineDRMLicenseHelper.renewLicense(player.asset?.video?.url!!, player.params, activity!!, this)
+                        showErrorMessage(getString(R.string.syncing_video))
+                    } else {
+                        val errorPlayerId = SentryLogger.generatePlayerIdString()
+                        SentryLogger.logDrmSessionException(error, player?.params, errorPlayerId)
+                        showErrorMessage(getString(R.string.license_error))
+                    }
+                }
+            }
         }
 
         private fun isDRMException(cause: Throwable): Boolean {

--- a/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
+++ b/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
@@ -1,9 +1,7 @@
 package com.tpstream.player.util
 
+import com.tpstream.player.*
 import com.tpstream.player.PlaybackException
-import com.tpstream.player.TPException
-import com.tpstream.player.TPStreamsSDK
-import com.tpstream.player.TpInitParams
 import io.sentry.Sentry
 
 internal object SentryLogger {
@@ -31,6 +29,17 @@ internal object SentryLogger {
             "Player error" +
                     " Code: ${error.errorCode}" +
                     " Code name: ${error.errorCodeName}" +
+                    " Message: ${error.message}" +
+                    " Video ID: ${params?.videoId}" +
+                    " AccessToken: ${params?.accessToken}" +
+                    " Org Code: ${TPStreamsSDK.orgCode}"
+        ) { scope -> scope.setTag("playerId", playerId) }
+    }
+
+    fun logDrmSessionException(error: DrmSessionException, params: TpInitParams?, playerId: String) {
+        Sentry.captureMessage(
+            "Player error" +
+                    " Code: ${error.errorCode}" +
                     " Message: ${error.message}" +
                     " Video ID: ${params?.videoId}" +
                     " AccessToken: ${params?.accessToken}" +

--- a/player/src/main/res/values/strings.xml
+++ b/player/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <!-- Error message -->
     <string name="syncing_video">Please wait… We are syncing video</string>
     <string name="no_internet_to_sync_license">Playback license has expired. Please connect to the internet to renew the playback license.</string>
-    <string name="license_error">Error in fetching video license. Please try again</string>
+    <string name="license_error">Error renewing playback license. Please try again.</string>
     <string name="license_request_failed">Couldn\'t fetch decryption key. Please try again</string>
     
     <string name="tp_streams_player_seek_forward_increment_ms">15000</string>


### PR DESCRIPTION
- In this commit, we added the option to call onAccessTokenExpired when the offline license is expired. Once we obtain the new access token, we fetch the DRM license key, replace the existing downloaded video, and reload the player.