### PR TITLE
fix: Check if fragment is added to activity before calling showErrorMessage

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -343,6 +343,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     }
 
     private fun showErrorMessage(message: String) {
+        if (!this@TpStreamPlayerFragment.isAdded) return
         viewBinding.errorMessage.visibility = View.VISIBLE
         viewBinding.errorMessage.text = message
     }


### PR DESCRIPTION
- In this commit, we ensure that the showErrorMessage function is called only if the fragment is added to the activity to prevent app crashes.