### PR TITLE
fix: Display Player error code instead of custom codes

### DIFF
--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -46,10 +46,10 @@ internal fun TPException.getErrorMessage(playerId: String): String {
 
 internal fun PlaybackException.getErrorMessage(playerId: String): String {
     return when (this.errorCode) {
-        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Error code: 5004. Player Id: $playerId"
-        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Error code: 5006. Player Id: $playerId"
-        PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Error code: 5003. Player Id: $playerId"
-        else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Error code: 5100. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Player code: ${this.errorCode}. Player Id: $playerId"
     }
 }
 


### PR DESCRIPTION
- Previously, we displayed custom error codes in error messages, while Exoplayer returns numerous error codes. We only showed four types of custom error codes.
- In this commit, we changed the error messages to display the actual player error codes. This will make it easier to identify and troubleshoot issues quickly.