### PR TITLE
fix: Add player SDK version in Sentry log

### DIFF
--- a/player/build.gradle
+++ b/player/build.gradle
@@ -30,6 +30,7 @@ android {
         } else {
             manifestPlaceholders = [serviceClassName: "com.google.android.exoplayer2.scheduler.PlatformScheduler\$PlatformSchedulerService"]
         }
+        buildConfigField "String", "TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME", "\"${project.findProperty("VERSION_NAME")}\""
     }
 
     buildTypes {

--- a/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
+++ b/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
@@ -1,6 +1,7 @@
 package com.tpstream.player.util
 
 import com.tpstream.player.*
+import com.tpstream.player.BuildConfig.TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME
 import com.tpstream.player.PlaybackException
 import io.sentry.Sentry
 
@@ -22,6 +23,7 @@ internal object SentryLogger {
                     " AccessToken: ${params?.accessToken}" +
                     " Org Code: ${TPStreamsSDK.orgCode}"
         ) { scope ->
+            scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
         }
@@ -37,6 +39,7 @@ internal object SentryLogger {
                     " AccessToken: ${params?.accessToken}" +
                     " Org Code: ${TPStreamsSDK.orgCode}"
         ) { scope ->
+            scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
         }
@@ -51,6 +54,7 @@ internal object SentryLogger {
                     " AccessToken: ${params?.accessToken}" +
                     " Org Code: ${TPStreamsSDK.orgCode}"
         ) { scope ->
+            scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
         }


### PR DESCRIPTION
- In this commit, we included the player SDK version in the Sentry log using the `TPStreamsAndroidPlayerSDKVersion` tag.