### PR TITLE
fix: Add custom object in Sentry

### DIFF
--- a/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
+++ b/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
@@ -26,6 +26,20 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
+            scope.setContexts(
+                "TPStreamsSDK",
+                mapOf(
+                    "SDK Version" to TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME,
+                    "Player Id" to playerId,
+                    "Error Type" to "Server error",
+                    "Error Code" to exception.response?.code,
+                    "Error Message" to exception.errorMessage,
+                    "Org Code" to TPStreamsSDK.orgCode,
+                    "Video ID" to params?.videoId,
+                    "AccessToken" to params?.accessToken,
+                    "userId" to params?.userId,
+                )
+            )
         }
     }
 
@@ -42,12 +56,26 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
+            scope.setContexts(
+                "TPStreamsSDK",
+                mapOf(
+                    "SDK Version" to TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME,
+                    "Player Id" to playerId,
+                    "Error Type" to "Player error",
+                    "Error Code" to error.errorCode,
+                    "Error Message" to error.errorCodeName,
+                    "Org Code" to TPStreamsSDK.orgCode,
+                    "Video ID" to params?.videoId,
+                    "AccessToken" to params?.accessToken,
+                    "userId" to params?.userId,
+                )
+            )
         }
     }
 
     fun logDrmSessionException(error: DrmSessionException, params: TpInitParams?, playerId: String) {
         Sentry.captureMessage(
-            "Player error" +
+            "Player DRM error" +
                     " Code: ${error.errorCode}" +
                     " Message: ${error.message}" +
                     " Video ID: ${params?.videoId}" +
@@ -57,6 +85,20 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
+            scope.setContexts(
+                "TPStreamsSDK",
+                mapOf(
+                    "SDK Version" to TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME,
+                    "Player Id" to playerId,
+                    "Error Type" to "Player DRM error",
+                    "Error Code" to error.errorCode,
+                    "Error Message" to error.message,
+                    "Org Code" to TPStreamsSDK.orgCode,
+                    "Video ID" to params?.videoId,
+                    "AccessToken" to params?.accessToken,
+                    "userId" to params?.userId,
+                )
+            )
         }
     }
 }


### PR DESCRIPTION
- In this commit, we introduced a custom object in Sentry to capture the following data: SDK Version, Player ID, Error Type, Error Code, Error Message, Org Code, Video ID, AccessToken, and userId.