### PR TITLE
fix: Add license_duration_seconds in DRM license URL query parameter

### DIFF
--- a/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
@@ -39,14 +39,14 @@ object TPStreamsSDK {
     internal fun constructOfflineDRMLicenseUrl(
         contentId: String?,
         accessToken: String?,
-        rentalDurationSeconds: Int
+        licenseDurationSeconds: Int
     ): String {
         return "${
             constructDRMLicenseUrl(
                 contentId,
                 accessToken
             )
-        }&drm_type=widevine&download=true&rental_duration_seconds=$rentalDurationSeconds"
+        }&drm_type=widevine&download=true&rental_duration_seconds=$licenseDurationSeconds&license_duration_seconds=$licenseDurationSeconds"
     }
 
     enum class Provider {

--- a/player/src/main/java/com/tpstream/player/TpInitParams.kt
+++ b/player/src/main/java/com/tpstream/player/TpInitParams.kt
@@ -12,7 +12,7 @@ data class TpInitParams (
     var videoId: String? = null,
     var isDownloadEnabled: Boolean = false,
     var startAt: Long = 0L,
-    var rentalDurationSeconds: Int = FIFTEEN_DAYS,
+    var licenseDurationSeconds: Int = FIFTEEN_DAYS,
     var userId: String? = null
 ): Parcelable {
 
@@ -22,7 +22,7 @@ data class TpInitParams (
         private var videoId: String? = null
         private var isDownloadEnabled: Boolean = false
         private var startAt: Long = 0L
-        var rentalDurationSeconds: Int = FIFTEEN_DAYS
+        var licenseDurationSeconds: Int = FIFTEEN_DAYS
         var userId: String? = null
 
         fun setAutoPlay(autoPlay: Boolean) = apply { this.autoPlay = autoPlay }
@@ -31,7 +31,7 @@ data class TpInitParams (
         fun setVideoId(videoId: String) = apply { this.videoId = videoId }
         fun enableDownloadSupport(isDownloadEnabled: Boolean) = apply { this.isDownloadEnabled = isDownloadEnabled }
         fun setOfflineLicenseExpireTime(@androidx.annotation.IntRange(from = 300) expireTimeInSecond: Int) =
-            apply { this.rentalDurationSeconds = expireTimeInSecond }
+            apply { this.licenseDurationSeconds = expireTimeInSecond }
         fun setUserId(userId: String) = apply { this.userId = userId }
 
         fun build(): TpInitParams {
@@ -44,7 +44,7 @@ data class TpInitParams (
                 videoId = videoId!!,
                 isDownloadEnabled = isDownloadEnabled,
                 startAt = startAt,
-                rentalDurationSeconds = rentalDurationSeconds,
+                licenseDurationSeconds = licenseDurationSeconds,
                 userId = userId
             )
         }

--- a/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
+++ b/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
@@ -85,7 +85,7 @@ internal object OfflineDRMLicenseHelper {
         val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(
             tpInitParams.videoId,
             tpInitParams.accessToken,
-            tpInitParams.rentalDurationSeconds
+            tpInitParams.licenseDurationSeconds
         )
         val offlineLicenseHelper = OfflineLicenseHelper.newWidevineInstance(
             drmLicenseURL,
@@ -105,7 +105,7 @@ internal object OfflineDRMLicenseHelper {
         format: Format,
         callback: DRMLicenseFetchCallback
     ) {
-        val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken, tpInitParams.rentalDurationSeconds)
+        val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(tpInitParams.videoId,tpInitParams.accessToken, tpInitParams.licenseDurationSeconds)
         val offlineLicenseHelper = OfflineLicenseHelper.newWidevineInstance(
             drmLicenseURL,
             VideoDownloadManager.invoke(context).getHttpDataSourceFactory(),

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -26,7 +26,7 @@ internal class VideoDownloadRequestCreationHandler(
     init {
         val url = asset.video.url
         trackSelectionParameters = DownloadHelper.getDefaultTrackSelectorParameters(context)
-        val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(params.videoId, params.accessToken, params.rentalDurationSeconds)
+        val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(params.videoId, params.accessToken, params.licenseDurationSeconds)
         mediaItem = MediaItemBuilder()
             .setUri(url)
             .setDrmConfiguration(


### PR DESCRIPTION
- Previously, we added rental_duration_seconds, but it was not effective according to Widevine policy. Rental duration is the total duration of license activation and usage before expiration. However, we also need to provide the license duration separately. By default, the license duration was 8 hours, so even if we set the rental duration to 15 days, the license would expire in 8 hours. In this commit, we added the license_duration_seconds query parameter to set both rental and license durations to the same value. The default value in the Android SDK is now set to 15 days.