### PR TITLE
fix: Remove default implementation of `onAccessTokenExpired` in `TPStreamPlayerListener`

### DIFF
--- a/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
@@ -18,7 +18,5 @@ interface TPStreamPlayerListener {
     fun onPlayerError(playbackError: PlaybackError) {}
     fun onMarkerCallback(timesInSeconds: Long) {}
     fun onFullScreenChanged(isFullScreen: Boolean) {}
-    fun onAccessTokenExpired(videoId: String, callback: (String) -> Unit) {
-        callback.invoke("")
-    }
+    fun onAccessTokenExpired(videoId: String, callback: (String) -> Unit)
 }


### PR DESCRIPTION
- Removed the default implementation of the `onAccessTokenExpired` method from the `TPStreamPlayerListener` interface.
- This change ensures that implementing classes must provide their own implementation for handling access token expiration, improving code clarity, and enforcing explicit behavior management.