### PR TITLE
enhancement: Add option to set initial video resolution in parameters

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -74,6 +74,7 @@ class PlayerActivity : AppCompatActivity() {
                 .setAutoPlay(true)
                 .setUserId("testUser")
                 .setOfflineLicenseExpireTime(FIFTEEN_DAYS)
+                .setInitialResolution(1080)
                 .enableDownloadSupport(true)
                 .build()
         }

--- a/player/src/main/java/com/tpstream/player/TpInitParams.kt
+++ b/player/src/main/java/com/tpstream/player/TpInitParams.kt
@@ -13,7 +13,8 @@ data class TpInitParams (
     var isDownloadEnabled: Boolean = false,
     var startAt: Long = 0L,
     var licenseDurationSeconds: Int = FIFTEEN_DAYS,
-    var userId: String? = null
+    var userId: String? = null,
+    var initialResolutionHeight: Int? = null
 ): Parcelable {
 
     class Builder {
@@ -24,6 +25,7 @@ data class TpInitParams (
         private var startAt: Long = 0L
         var licenseDurationSeconds: Int = FIFTEEN_DAYS
         var userId: String? = null
+        private var initialResolutionHeight: Int? = null
 
         fun setAutoPlay(autoPlay: Boolean) = apply { this.autoPlay = autoPlay }
         fun startAt(timeInSeconds: Long) = apply { this.startAt = timeInSeconds }
@@ -33,6 +35,7 @@ data class TpInitParams (
         fun setOfflineLicenseExpireTime(@androidx.annotation.IntRange(from = 300) expireTimeInSecond: Int) =
             apply { this.licenseDurationSeconds = expireTimeInSecond }
         fun setUserId(userId: String) = apply { this.userId = userId }
+        fun setInitialResolution(height: Int) = apply { this.initialResolutionHeight = height }
 
         fun build(): TpInitParams {
             require(!accessToken.isNullOrBlank()) { "accessToken must not be null or empty" }
@@ -45,7 +48,8 @@ data class TpInitParams (
                 isDownloadEnabled = isDownloadEnabled,
                 startAt = startAt,
                 licenseDurationSeconds = licenseDurationSeconds,
-                userId = userId
+                userId = userId,
+                initialResolutionHeight = initialResolutionHeight
             )
         }
     }

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -121,9 +121,25 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
     internal fun playVideo(url: String,startPosition: Long = 0) {
         exoPlayer.playWhenReady = params.autoPlay?: true
         exoPlayer.setMediaSource(getMediaSourceFactory().createMediaSource(getMediaItem(url)))
+        exoPlayer.trackSelectionParameters = getInitialTrackSelectionParameter()
         exoPlayer.seekTo(startPosition)
         exoPlayer.prepare()
         tpStreamPlayerImplCallBack?.onPlayerPrepare()
+    }
+
+    private fun getInitialTrackSelectionParameter(): TrackSelectionParameters {
+        if (!this::params.isInitialized || params.initialResolutionHeight == null) {
+            return getTrackSelectionParameters()
+        }
+        val height = params.initialResolutionHeight!!
+        // Set minimum and maximum video height to filter available tracks.
+        // If a track with the exact specified height is available, it will be selected.
+        // If no exact match is found, the player will select the smallest available resolution
+        // that is less than or equal to the specified height.
+        return TrackSelectionParametersBuilder(context)
+            .setMinVideoSize(Int.MIN_VALUE, height)
+            .setMaxVideoSize(Int.MAX_VALUE, height)
+            .build()
     }
 
     private fun getMediaSourceFactory(): MediaSourceFactory {

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -196,6 +196,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
                     showNoticeScreen(it)
                 }
                 initializeSubtitleView()
+                updateSelectedResolution()
             }
         }
     }
@@ -208,6 +209,12 @@ class TPStreamPlayerView @JvmOverloads constructor(
             val bottomMarginInPx = (bottomMarginInDp * density).toInt()
             (playerView.subtitleView?.layoutParams as? MarginLayoutParams)?.bottomMargin =
                 bottomMarginInPx
+        }
+    }
+
+    private fun updateSelectedResolution() {
+        player.params.initialResolutionHeight?.let {
+            selectedResolution = ResolutionOptions.ADVANCED
         }
     }
 


### PR DESCRIPTION
- In this commit, we added a feature to specify the initial video resolution through the parameters. This enhancement allows us to remember and restore the user's last video resolution state.