### PR TITLE
fix: Add TPStreamsSDK provider in Sentry log

### DIFF
--- a/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamSDK.kt
@@ -1,8 +1,9 @@
 package com.tpstream.player
 
 object TPStreamsSDK {
-    private var provider: Provider = Provider.TPStreams
+    private var _provider: Provider = Provider.TPStreams
     private var _orgCode: String? = null
+    val provider : Provider get() = _provider
     val orgCode: String
         get() {
             if (_orgCode == null) {
@@ -17,7 +18,7 @@ object TPStreamsSDK {
         }
 
         this._orgCode = orgCode
-        this.provider = provider
+        this._provider = provider
     }
 
     fun constructVideoInfoUrl(contentId: String?, accessToken: String?): String {

--- a/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
+++ b/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
@@ -30,6 +30,7 @@ internal object SentryLogger {
                 "TPStreamsSDK",
                 mapOf(
                     "SDK Version" to TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME,
+                    "Provider" to TPStreamsSDK.provider.name,
                     "Player Id" to playerId,
                     "Error Type" to "Server error",
                     "Error Code" to exception.response?.code,
@@ -60,6 +61,7 @@ internal object SentryLogger {
                 "TPStreamsSDK",
                 mapOf(
                     "SDK Version" to TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME,
+                    "Provider" to TPStreamsSDK.provider.name,
                     "Player Id" to playerId,
                     "Error Type" to "Player error",
                     "Error Code" to error.errorCode,
@@ -89,6 +91,7 @@ internal object SentryLogger {
                 "TPStreamsSDK",
                 mapOf(
                     "SDK Version" to TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME,
+                    "Provider" to TPStreamsSDK.provider.name,
                     "Player Id" to playerId,
                     "Error Type" to "Player DRM error",
                     "Error Code" to error.errorCode,


### PR DESCRIPTION
- In this commit, we included the TPStreamsSDK provider in the Sentry log using the `Provider` tag.