### PR TITLE
fix: Add `isDrmProtected` field to Asset.Video Model

### DIFF
--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -83,7 +83,7 @@ data class Video(
     var totalSize: Long = 0,
     var downloadState: DownloadStatus? = null,
     val tracks: List<Track>? = null,
-    val enableDRM: Boolean? = false
+    val isDrmProtected: Boolean? = false
 ){
     val isTranscodingCompleted: Boolean
         get() = transcodingStatus == "Completed"

--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -82,7 +82,8 @@ data class Video(
     var bytesDownloaded: Long = 0,
     var totalSize: Long = 0,
     var downloadState: DownloadStatus? = null,
-    val tracks: List<Track>? = null
+    val tracks: List<Track>? = null,
+    val enableDRM: Boolean? = false
 ){
     val isTranscodingCompleted: Boolean
         get() = transcodingStatus == "Completed"

--- a/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
@@ -21,7 +21,7 @@ internal fun LocalAsset.asDomainAsset(): Asset {
             downloadState = this.downloadState,
             width = this.videoWidth,
             height = this.videoHeight,
-            enableDRM = this.url.isDRMVideo()
+            isDrmProtected = this.url.isDrmProtected()
         ),
         folderTree = this.folderTree,
         downloadStartTimeMs = this.downloadStartTimeMs,
@@ -37,7 +37,7 @@ internal fun NetworkAsset.asDomainAsset(): Asset {
     val thumbnailUrl = if (networkVideo != null) networkVideo.preview_thumbnail_url
         ?: "" else thumbnail ?: ""
     val url = if (networkVideo != null) {
-        if (networkVideo.enable_drm == true) networkVideo.dash_url
+        if (networkVideo.isDrmProtected == true) networkVideo.dash_url
             ?: "" else networkVideo.playback_url ?: ""
     } else {
         dashUrl ?: url ?: ""
@@ -54,7 +54,7 @@ internal fun NetworkAsset.asDomainAsset(): Asset {
             tracks = this.networkVideo?.tracks?.map {
                 it.asDomainTracks()
             },
-            enableDRM = networkVideo?.enable_drm
+            isDrmProtected = networkVideo?.isDrmProtected
         ),
         description = description ?: "",
         liveStream = getDomainLiveStream(this),
@@ -111,4 +111,4 @@ internal fun Asset.asLocalAsset(): LocalAsset {
     )
 }
 
-internal fun String.isDRMVideo() = this.contains(".mpd")
+internal fun String.isDrmProtected() = this.contains(".mpd")

--- a/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
@@ -21,6 +21,7 @@ internal fun LocalAsset.asDomainAsset(): Asset {
             downloadState = this.downloadState,
             width = this.videoWidth,
             height = this.videoHeight,
+            enableDRM = this.url.isDRMVideo()
         ),
         folderTree = this.folderTree,
         downloadStartTimeMs = this.downloadStartTimeMs,
@@ -52,7 +53,8 @@ internal fun NetworkAsset.asDomainAsset(): Asset {
             transcodingStatus = transcodingStatus ?: "",
             tracks = this.networkVideo?.tracks?.map {
                 it.asDomainTracks()
-            }
+            },
+            enableDRM = networkVideo?.enable_drm
         ),
         description = description ?: "",
         liveStream = getDomainLiveStream(this),
@@ -108,3 +110,5 @@ internal fun Asset.asLocalAsset(): LocalAsset {
         metadata = this.metadata
     )
 }
+
+internal fun String.isDRMVideo() = this.contains(".mpd")

--- a/player/src/main/java/com/tpstream/player/data/source/network/NetworkAsset.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/network/NetworkAsset.kt
@@ -48,7 +48,8 @@ internal data class NetworkAsset(
         val resolutions: Array<String>?,
         val video_codec: String?,
         val audio_codec: String?,
-        val enable_drm: Boolean?,
+        @SerializedName("enable_drm")
+        val isDrmProtected : Boolean?,
         val tracks: List<Track>?,
         val duration: Long?
     ) {

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -9,6 +9,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.tpstream.player.*
@@ -230,6 +231,8 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
                 tpStreamPlayerView.hidePlayButton()
                 tpStreamPlayerView.showReplayButton()
             }
+
+            Toast.makeText(requireContext(),player.asset?.video?.isDrmProtected.toString(),Toast.LENGTH_SHORT).show()
         }
 
         override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -9,7 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
-import android.widget.Toast
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.tpstream.player.*
@@ -231,8 +230,6 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
                 tpStreamPlayerView.hidePlayButton()
                 tpStreamPlayerView.showReplayButton()
             }
-
-            Toast.makeText(requireContext(),player.asset?.video?.isDrmProtected.toString(),Toast.LENGTH_SHORT).show()
         }
 
         override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {


### PR DESCRIPTION
- In this commit, we added the `isDrmProtected` field to the `Asset.Video` model, which was previously missing. This field allows us to identify whether a video is DRM-protected. For online playback, this value is obtained from the network. For offline playback, DRM protection is determined by checking if the playback URL ends with `.mpd`.
- Additionally, we updated the `enable_drm` field in NetworkAsset to `isDrmProtected`.





