### PR TITLE
fix: Add param initialization check to prevent crash

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -188,7 +188,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
     private fun initializeLoadCompleteListener() {
         player.setLoadCompleteListener {
             (context as FragmentActivity).runOnUiThread {
-                if (player.params.isDownloadEnabled && it.isDownloadable) {
+                if (player.isParamsInitialized() && player.params.isDownloadEnabled && it.isDownloadable) {
                     downloadButton?.isVisible = true
                     updateDownloadButtonImage()
                 }


### PR DESCRIPTION
- Ensure player parameters are properly initialized before checking download conditions to prevent crashes in edge cases. Added `isParamsInitialized()` validation before displaying the download button.