### PR TITLE
enhancement: Add 1.75x playback speed in player

### DIFF
--- a/player/src/main/java/com/tpstream/player/Mapping.kt
+++ b/player/src/main/java/com/tpstream/player/Mapping.kt
@@ -7,6 +7,7 @@ internal typealias TimeBar = androidx.media3.ui.TimeBar
 internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
+internal typealias ExoplayerLayoutID = androidx.media3.ui.R.layout
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/java/com/tpstream/player/Mapping.kt
+++ b/player/src/main/java/com/tpstream/player/Mapping.kt
@@ -8,6 +8,7 @@ internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
 internal typealias ControllerVisibilityListener = androidx.media3.ui.PlayerView.ControllerVisibilityListener
+internal typealias PlayerControlView = androidx.media3.ui.PlayerControlView
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/java/com/tpstream/player/Mapping.kt
+++ b/player/src/main/java/com/tpstream/player/Mapping.kt
@@ -7,7 +7,6 @@ internal typealias TimeBar = androidx.media3.ui.TimeBar
 internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
-internal typealias ExoplayerLayoutID = androidx.media3.ui.R.layout
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/java/com/tpstream/player/Mapping.kt
+++ b/player/src/main/java/com/tpstream/player/Mapping.kt
@@ -7,6 +7,7 @@ internal typealias TimeBar = androidx.media3.ui.TimeBar
 internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
+internal typealias ControllerVisibilityListener = androidx.media3.ui.PlayerView.ControllerVisibilityListener
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackSpeed.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackSpeed.kt
@@ -1,6 +1,6 @@
 package com.tpstream.player.constants
 
-enum class PlaybackSpeed(val value: Float, val text: String) {
+internal enum class PlaybackSpeed(val value: Float, val text: String) {
     PLAYBACK_SPEED_0_25(0.25f, "0.25x"),
     PLAYBACK_SPEED_0_5(0.5f, "0.5x"),
     PLAYBACK_SPEED_0_75(0.75f, "0.75x"),

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackSpeed.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackSpeed.kt
@@ -1,11 +1,12 @@
 package com.tpstream.player.constants
 
-internal enum class PlaybackSpeed(val value: Float, val text: String) {
+enum class PlaybackSpeed(val value: Float, val text: String) {
     PLAYBACK_SPEED_0_25(0.25f, "0.25x"),
     PLAYBACK_SPEED_0_5(0.5f, "0.5x"),
     PLAYBACK_SPEED_0_75(0.75f, "0.75x"),
     PLAYBACK_SPEED_1_0(1.0f, "1x"),
     PLAYBACK_SPEED_1_25(1.25f, "1.25x"),
     PLAYBACK_SPEED_1_5(1.5f, "1.5x"),
+    PLAYBACK_SPEED_1_75(1.75f, "1.75x"),
     PLAYBACK_SPEED_2_0(2.0f, "2x")
 }

--- a/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
+++ b/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
@@ -25,7 +25,7 @@ internal class PlaybackSpeedPopupWindow(
         popupWindow = createPopupWindow(popupView)
         setupRecyclerView(popupView, TPStreamPlayerView.context)
         adjustPopupWindowHeight()
-        extendControllerShowTimeout()
+        extendControllerTimeout()
         showPopupWindow()
     }
 
@@ -76,13 +76,13 @@ internal class PlaybackSpeedPopupWindow(
         popupWindow?.height = (TPStreamPlayerView.height * POPUP_WINDOW_HEIGHT_RATIO).toInt()
     }
 
-    private fun extendControllerShowTimeout() {
+    private fun extendControllerTimeout() {
         // Since we are adding the custom playback speed selection option, we don't have access
         // to control the player controller auto-hide option. So whenever the user clicks the
         // playback speed option, we set the player controller timeout duration to 10 seconds.
         // This helps the user select the speed option without interruption.
         TPStreamPlayerView.playerView.controllerShowTimeoutMs =
-            PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS * EXTENDED_SHOW_TIMEOUT_MULTIPLIER
+            PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS * INCREASED_TIMEOUT_TWICE
     }
 
     private fun showPopupWindow() {
@@ -109,7 +109,7 @@ internal class PlaybackSpeedPopupWindow(
 
     companion object {
         private const val POPUP_WINDOW_HEIGHT_RATIO = 0.75
-        private const val EXTENDED_SHOW_TIMEOUT_MULTIPLIER = 2
+        private const val INCREASED_TIMEOUT_TWICE   = 2
         private const val POPUP_WINDOW_OFFSET = 16
     }
 }

--- a/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
+++ b/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
@@ -1,0 +1,71 @@
+package com.tpstream.player.ui
+
+import com.tpstream.player.TpStreamPlayerImpl
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.PopupWindow
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.tpstream.player.R
+import com.tpstream.player.constants.PlaybackSpeed
+import com.tpstream.player.ui.adapter.PlaybackSpeedAdapter
+
+internal class PlaybackSpeedPopupWindow(
+    private val player: TpStreamPlayerImpl,
+    private val playerView: TPStreamPlayerView
+) {
+    private var popupWindow: PopupWindow? = null
+
+    fun show() {
+        val inflater =
+            playerView.context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        val popupView = inflater.inflate(R.layout.popup_window_layout, null)
+
+        popupWindow = createPopupWindow(popupView)
+        setupRecyclerView(popupView, playerView.context)
+
+        popupWindow?.height = (playerView.height * 0.75).toInt()
+        popupWindow?.showAsDropDown(playerView, Int.MAX_VALUE, -((popupWindow?.height ?: 0) + 16))
+    }
+
+    private fun createPopupWindow(popupView: View): PopupWindow {
+        return PopupWindow(
+            popupView,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            true
+        )
+    }
+
+    private fun setupRecyclerView(popupView: View, context: Context) {
+        val recyclerView: RecyclerView = popupView.findViewById(R.id.recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+
+        val adapter = PlaybackSpeedAdapter(
+            context,
+            player.exoPlayer.playbackParameters.speed,
+            PlaybackSpeed.values().toList()
+        ) { playbackSpeed ->
+            player.exoPlayer.playbackParameters =
+                player.exoPlayer.playbackParameters.withSpeed(playbackSpeed.value)
+            setPlaybackSpeedText(playbackSpeed.value)
+            dismiss()
+        }
+
+        recyclerView.adapter = adapter
+    }
+
+    private fun setPlaybackSpeedText(speed: Float) {
+        val playbackSpeedButton = playerView.findViewById<Button>(R.id.playback_speed)
+        val playbackSpeed = PlaybackSpeed.values().find { it.value == speed }
+        playbackSpeedButton.text = playbackSpeed?.text
+    }
+
+    fun dismiss() {
+        popupWindow?.dismiss()
+        popupWindow = null
+    }
+}

--- a/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
+++ b/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
@@ -16,16 +16,16 @@ import com.tpstream.player.ui.adapter.PlaybackSpeedAdapter
 
 internal class PlaybackSpeedPopupWindow(
     private val player: TpStreamPlayerImpl,
-    private val TPStreamPlayerView: TPStreamPlayerView
+    private val tpStreamPlayerView: TPStreamPlayerView
 ) {
-    private var popupWindow: PopupWindow? = null
+    var playbackSpeedPopupWindow: PopupWindow? = null
 
     fun show() {
-        val popupView = inflatePopupView(TPStreamPlayerView.context)
-        popupWindow = createPopupWindow(popupView)
-        setupRecyclerView(popupView, TPStreamPlayerView.context)
+        val popupView = inflatePopupView(tpStreamPlayerView.context)
+        playbackSpeedPopupWindow = createPopupWindow(popupView)
+        setupRecyclerView(popupView, tpStreamPlayerView.context)
         adjustPopupWindowHeight()
-        extendControllerTimeout()
+        increaseControllerTimeoutForPopup()
         showPopupWindow()
     }
 
@@ -49,16 +49,14 @@ internal class PlaybackSpeedPopupWindow(
         recyclerView.adapter = createAdapter(context)
     }
 
-    private fun createAdapter(context: Context): PlaybackSpeedAdapter {
-        return PlaybackSpeedAdapter(
-            context,
-            player.exoPlayer.playbackParameters.speed,
-            PlaybackSpeed.values().toList()
-        ) { playbackSpeed ->
-            setPlayerPlaybackSpeed(playbackSpeed.value)
-            updatePlaybackSpeedText(playbackSpeed.value)
-            dismiss()
-        }
+    private fun createAdapter(context: Context) = PlaybackSpeedAdapter(
+        context,
+        player.exoPlayer.playbackParameters.speed,
+        PlaybackSpeed.values().toList()
+    ) { playbackSpeed ->
+        setPlayerPlaybackSpeed(playbackSpeed.value)
+        updatePlaybackSpeedText(playbackSpeed.value)
+        dismiss()
     }
 
     private fun setPlayerPlaybackSpeed(speed: Float) {
@@ -67,49 +65,50 @@ internal class PlaybackSpeedPopupWindow(
     }
 
     private fun updatePlaybackSpeedText(speed: Float) {
-        val playbackSpeedButton = TPStreamPlayerView.findViewById<Button>(R.id.playback_speed)
-        val playbackSpeed = PlaybackSpeed.values().find { it.value == speed }
-        playbackSpeedButton.text = playbackSpeed?.text
+        val playbackSpeedButton = tpStreamPlayerView.findViewById<Button>(R.id.playback_speed)
+        val playbackSpeedText = PlaybackSpeed.values().find { it.value == speed }
+        playbackSpeedButton.text = playbackSpeedText?.text
     }
 
     private fun adjustPopupWindowHeight() {
-        popupWindow?.height = (TPStreamPlayerView.height * POPUP_WINDOW_HEIGHT_RATIO).toInt()
+        playbackSpeedPopupWindow?.height =
+            (tpStreamPlayerView.height * POPUP_WINDOW_HEIGHT_RATIO).toInt()
     }
 
-    private fun extendControllerTimeout() {
+    private fun increaseControllerTimeoutForPopup() {
         // Since we are adding the custom playback speed selection option, we don't have access
         // to control the player controller auto-hide option. So whenever the user clicks the
         // playback speed option, we set the player controller timeout duration to 10 seconds.
         // This helps the user select the speed option without interruption.
-        TPStreamPlayerView.playerView.controllerShowTimeoutMs =
+        tpStreamPlayerView.playerView.controllerShowTimeoutMs =
             PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS * INCREASED_TIMEOUT_TWICE
     }
 
     private fun showPopupWindow() {
-        popupWindow?.showAsDropDown(
-            TPStreamPlayerView,
+        playbackSpeedPopupWindow?.showAsDropDown(
+            tpStreamPlayerView,
             Int.MAX_VALUE,
-            -((popupWindow?.height ?: 0) + POPUP_WINDOW_OFFSET)
+            -((playbackSpeedPopupWindow?.height ?: 0) + POPUP_WINDOW_OFFSET)
         )
     }
 
     fun dismiss() {
-        resetControllerTimeout()
-        popupWindow?.dismiss()
-        popupWindow = null
+        restoreDefaultControllerTimeout()
+        playbackSpeedPopupWindow?.dismiss()
+        playbackSpeedPopupWindow = null
     }
 
-    private fun resetControllerTimeout() {
+    private fun restoreDefaultControllerTimeout() {
         // We set 10 seconds for the player controller hide timeout when opening the
         // playback speed option. We reset the value to the default when dismissing the
         // playback speed options.
-        TPStreamPlayerView.playerView.controllerShowTimeoutMs =
+        tpStreamPlayerView.playerView.controllerShowTimeoutMs =
             PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS
     }
 
     companion object {
         private const val POPUP_WINDOW_HEIGHT_RATIO = 0.75
-        private const val INCREASED_TIMEOUT_TWICE   = 2
+        private const val INCREASED_TIMEOUT_TWICE = 2
         private const val POPUP_WINDOW_OFFSET = 16
     }
 }

--- a/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
+++ b/player/src/main/java/com/tpstream/player/ui/PlaybackSpeedPopupWindow.kt
@@ -9,6 +9,7 @@ import android.widget.LinearLayout
 import android.widget.PopupWindow
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.tpstream.player.PlayerControlView
 import com.tpstream.player.R
 import com.tpstream.player.constants.PlaybackSpeed
 import com.tpstream.player.ui.adapter.PlaybackSpeedAdapter
@@ -52,6 +53,8 @@ internal class PlaybackSpeedPopupWindow(
             player.exoPlayer.playbackParameters =
                 player.exoPlayer.playbackParameters.withSpeed(playbackSpeed.value)
             setPlaybackSpeedText(playbackSpeed.value)
+            // Reset Controller show timeout to default
+            playerView.playerView.controllerShowTimeoutMs = PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS
             dismiss()
         }
 

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -70,7 +70,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
         registerResolutionChangeListener()
         initializeViewModel()
         initializeNoticeScreen()
-        initializeControllerVisibilityListener()
+        setupPlayerControlsVisibilityListener()
     }
 
     private fun registerDownloadListener() {
@@ -107,10 +107,10 @@ class TPStreamPlayerView @JvmOverloads constructor(
         addView(noticeScreenLayout)
     }
 
-    private fun initializeControllerVisibilityListener(){
-        playerView.setControllerVisibilityListener(androidx.media3.ui.PlayerView.ControllerVisibilityListener {
+    private fun setupPlayerControlsVisibilityListener(){
+        playerView.setControllerVisibilityListener(ControllerVisibilityListener {
             if(!playerView.isControllerFullyVisible){
-                dismissPopupMenu()
+                dismissPlaybackSpeedPopupMenu()
             }
         })
     }
@@ -302,7 +302,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
         ) { playbackSpeed ->
             player.exoPlayer.playbackParameters = player.exoPlayer.playbackParameters.withSpeed(playbackSpeed.value)
             setPlaybackSpeedText(playbackSpeed.value)
-            dismissPopupMenu()
+            dismissPlaybackSpeedPopupMenu()
         }
 
         recyclerView.adapter = adapter
@@ -314,7 +314,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
         playbackSpeedButton.text = playbackSpeed?.text
     }
 
-    private fun dismissPopupMenu() {
+    private fun dismissPlaybackSpeedPopupMenu() {
         popupWindow?.dismiss()
         popupWindow = null
     }

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -39,7 +39,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
 ) : FrameLayout(context, attrs, defStyleAttr), ViewModelStoreOwner {
     private val binding: TpStreamPlayerViewBinding =
         TpStreamPlayerViewBinding.inflate(LayoutInflater.from(context), this, true)
-    private var playerView: PlayerView = binding.root.findViewById(R.id.player_view)
+    internal var playerView: PlayerView = binding.root.findViewById(R.id.player_view)
     private lateinit var player: TpStreamPlayerImpl
     private var downloadButton: ImageButton? = null
     private var resolutionButton : ImageButton? = null
@@ -105,6 +105,8 @@ class TPStreamPlayerView @JvmOverloads constructor(
     private fun setupPlayerControlsVisibilityListener() {
         playerView.setControllerVisibilityListener(ControllerVisibilityListener {
             if (!playerView.isControllerFullyVisible) {
+                // Reset Controller show timeout to default
+                playerView.controllerShowTimeoutMs = PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS
                 playbackSpeedPopupWindow?.dismiss()
             }
         })
@@ -264,6 +266,8 @@ class TPStreamPlayerView @JvmOverloads constructor(
         playbackSpeedPopupWindow = PlaybackSpeedPopupWindow(player, this)
         val playbackSpeedButton = playerView.findViewById<Button>(R.id.playback_speed)
         playbackSpeedButton.setOnClickListener {
+            // Set Controller show timeout to 10 Sec
+            playerView.controllerShowTimeoutMs = PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS * 2
             playbackSpeedPopupWindow?.show()
         }
     }

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -8,6 +8,7 @@ import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.util.AttributeSet
+import android.util.Log
 import android.view.*
 import android.widget.*
 import androidx.annotation.ColorInt
@@ -129,26 +130,19 @@ class TPStreamPlayerView @JvmOverloads constructor(
         val inflater = anchor.context.getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
         val popupView = inflater.inflate(R.layout.popup_window_layout, null)
 
-        // Create the PopupWindow
         popupWindow = PopupWindow(popupView,
             LinearLayout.LayoutParams.WRAP_CONTENT,
             LinearLayout.LayoutParams.WRAP_CONTENT,
             true)
 
-        // Set up the RecyclerView
         val recyclerView: RecyclerView = popupView.findViewById(R.id.recycler_view)
         recyclerView.layoutManager = LinearLayoutManager(anchor.context)
-        //recyclerView.layoutParams.height =
 
         val adapter = CustomAdapter(anchor.context, PlaybackSpeed.values().toList())
         recyclerView.adapter = adapter
 
         popupWindow?.height = (playerView.height * 0.75).toInt()
-
-        // Show the PopupWindow
-        //popupWindow?.showAsDropDown(anchor)
-
-        popupWindow?.showAsDropDown(this, Int.MAX_VALUE,- (popupWindow?.height?: 0))
+        popupWindow?.showAsDropDown(this, Int.MAX_VALUE,- (popupWindow!!.height + 16))
     }
 
     private fun setPlaybackSpeedText(speed: Float) {
@@ -158,8 +152,8 @@ class TPStreamPlayerView @JvmOverloads constructor(
     }
 
     private fun dismissPopupMenu() {
-        //popupWindow?.dismiss()
-        //popupWindow = null
+        popupWindow?.dismiss()
+        popupWindow = null
     }
 
     private fun onDownloadButtonClick() {
@@ -605,9 +599,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
 
         override fun onBindViewHolder(holder: ViewHolder, position: Int) {
             val playbackSpeed = items[position]
-            holder.text.text = playbackSpeed.text
-            // Set up the check visibility or any other logic here if needed
-
+            holder.text.text = if (playbackSpeed.value == 1.0f) "Normal" else playbackSpeed.text
             if (player.exoPlayer.playbackParameters.speed == playbackSpeed.value) {
                 holder.itemView.isSelected = true;
                 holder.check.visibility = VISIBLE;
@@ -615,7 +607,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
                 holder.itemView.isSelected = false;
                 holder.check.visibility = INVISIBLE;
             }
-
             holder.itemView.setOnClickListener {
                 player.exoPlayer.playbackParameters =
                     player.exoPlayer.playbackParameters.withSpeed(playbackSpeed.value)

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -102,9 +102,9 @@ class TPStreamPlayerView @JvmOverloads constructor(
         addView(noticeScreenLayout)
     }
 
-    private fun setupPlayerControlsVisibilityListener(){
+    private fun setupPlayerControlsVisibilityListener() {
         playerView.setControllerVisibilityListener(ControllerVisibilityListener {
-            if(!playerView.isControllerFullyVisible){
+            if (!playerView.isControllerFullyVisible) {
                 playbackSpeedPopupWindow?.dismiss()
             }
         })

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -10,7 +10,6 @@ import android.graphics.Color
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.*
 import androidx.annotation.ColorInt
 import androidx.core.view.isVisible
@@ -114,53 +113,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
                 dismissPopupMenu()
             }
         })
-    }
-
-    private fun initializePlaybackSpeedButton() {
-        val playbackSpeedButton = playerView.findViewById<Button>(R.id.playback_speed)
-        playbackSpeedButton.setOnClickListener { view ->
-            showPlaybackSpeedPopupWindow(view)
-        }
-    }
-
-    private fun showPlaybackSpeedPopupWindow(anchor: View) {
-        val inflater = anchor.context.getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
-        val popupView = inflater.inflate(R.layout.popup_window_layout, null)
-
-        popupWindow = PopupWindow(popupView,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            true)
-
-        val recyclerView: RecyclerView = popupView.findViewById(R.id.recycler_view)
-        recyclerView.layoutManager = LinearLayoutManager(anchor.context)
-
-        val adapter = PlaybackSpeedAdapter(
-            anchor.context,
-            player.exoPlayer.playbackParameters.speed,
-            PlaybackSpeed.values().toList()
-        ) { playbackSpeed ->
-            player.exoPlayer.playbackParameters =
-                player.exoPlayer.playbackParameters.withSpeed(playbackSpeed.value)
-            setPlaybackSpeedText(playbackSpeed.value)
-            popupWindow?.dismiss()
-        }
-
-        recyclerView.adapter = adapter
-
-        popupWindow?.height = (playerView.height * 0.75).toInt()
-        popupWindow?.showAsDropDown(this, Int.MAX_VALUE,- (popupWindow!!.height + 16))
-    }
-
-    private fun setPlaybackSpeedText(speed: Float) {
-        val playbackSpeedButton = playerView.findViewById<Button>(R.id.playback_speed)
-        val playbackSpeed = PlaybackSpeed.values().find { it.value == speed }
-        playbackSpeedButton.text = playbackSpeed?.text
-    }
-
-    private fun dismissPopupMenu() {
-        popupWindow?.dismiss()
-        popupWindow = null
     }
 
     private fun onDownloadButtonClick() {
@@ -311,6 +263,60 @@ class TPStreamPlayerView @JvmOverloads constructor(
         if (this[time]?.shouldDeleteAfterDelivery == true) {
             this[time]?.isPlayed = true
         }
+    }
+
+    private fun initializePlaybackSpeedButton() {
+        val playbackSpeedButton = playerView.findViewById<Button>(R.id.playback_speed)
+        playbackSpeedButton.setOnClickListener { view ->
+            showPlaybackSpeedPopupWindow(view)
+        }
+    }
+
+    private fun showPlaybackSpeedPopupWindow(anchor: View) {
+        val inflater = anchor.context.getSystemService(LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        val popupView = inflater.inflate(R.layout.popup_window_layout, null)
+
+        popupWindow = createPopupWindow(popupView)
+        setupRecyclerView(popupView, anchor.context)
+
+        popupWindow?.height = (playerView.height * 0.75).toInt()
+        popupWindow?.showAsDropDown(this, Int.MAX_VALUE,- (popupWindow!!.height + 16))
+    }
+
+    private fun createPopupWindow(popupView: View): PopupWindow {
+        return PopupWindow(popupView,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            true
+        )
+    }
+
+    private fun setupRecyclerView(popupView: View, context: Context) {
+        val recyclerView: RecyclerView = popupView.findViewById(R.id.recycler_view)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+
+        val adapter = PlaybackSpeedAdapter(
+            context,
+            player.exoPlayer.playbackParameters.speed,
+            PlaybackSpeed.values().toList()
+        ) { playbackSpeed ->
+            player.exoPlayer.playbackParameters = player.exoPlayer.playbackParameters.withSpeed(playbackSpeed.value)
+            setPlaybackSpeedText(playbackSpeed.value)
+            dismissPopupMenu()
+        }
+
+        recyclerView.adapter = adapter
+    }
+
+    private fun setPlaybackSpeedText(speed: Float) {
+        val playbackSpeedButton = playerView.findViewById<Button>(R.id.playback_speed)
+        val playbackSpeed = PlaybackSpeed.values().find { it.value == speed }
+        playbackSpeedButton.text = playbackSpeed?.text
+    }
+
+    private fun dismissPopupMenu() {
+        popupWindow?.dismiss()
+        popupWindow = null
     }
 
     private fun updateDownloadButtonImage() {
@@ -588,12 +594,10 @@ class TPStreamPlayerView @JvmOverloads constructor(
             it.start()
         }
     }
+
 }
 
 internal interface TPStreamPlayerViewCallBack {
     fun hideErrorView()
     fun showErrorMessage(message: String)
 }
-
-
-

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -105,8 +105,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
     private fun setupPlayerControlsVisibilityListener() {
         playerView.setControllerVisibilityListener(ControllerVisibilityListener {
             if (!playerView.isControllerFullyVisible) {
-                // Reset Controller show timeout to default
-                playerView.controllerShowTimeoutMs = PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS
                 playbackSpeedPopupWindow?.dismiss()
             }
         })
@@ -266,8 +264,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
         playbackSpeedPopupWindow = PlaybackSpeedPopupWindow(player, this)
         val playbackSpeedButton = playerView.findViewById<Button>(R.id.playback_speed)
         playbackSpeedButton.setOnClickListener {
-            // Set Controller show timeout to 10 Sec
-            playerView.controllerShowTimeoutMs = PlayerControlView.DEFAULT_SHOW_TIMEOUT_MS * 2
             playbackSpeedPopupWindow?.show()
         }
     }

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -232,11 +232,6 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
             }
         }
 
-        override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
-            super.onPlaybackParametersChanged(playbackParameters)
-            tpStreamPlayerView.setPlaybackSpeedText(playbackParameters.speed)
-        }
-
         override fun onPlayerError(error: PlaybackException) {
             super.onPlayerError(error)
             val errorPlayerId = SentryLogger.generatePlayerIdString()

--- a/player/src/main/java/com/tpstream/player/ui/adapter/PlaybackSpeedAdapter.kt
+++ b/player/src/main/java/com/tpstream/player/ui/adapter/PlaybackSpeedAdapter.kt
@@ -1,0 +1,45 @@
+package com.tpstream.player.ui.adapter
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.tpstream.player.R
+import com.tpstream.player.constants.PlaybackSpeed
+
+internal class PlaybackSpeedAdapter(
+    private val context: Context,
+    private val selectedSpeed: Float,
+    private val items: List<PlaybackSpeed>,
+    private val onItemClick: (PlaybackSpeed) -> Unit
+) : RecyclerView.Adapter<PlaybackSpeedAdapter.ViewHolder>() {
+
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val check: ImageView = itemView.findViewById(R.id.check)
+        val text: TextView = itemView.findViewById(R.id.text)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view =
+            LayoutInflater.from(context).inflate(R.layout.playback_speed_list_item, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val playbackSpeed = items[position]
+        holder.text.text = if (playbackSpeed.value == 1.0f) "Normal" else playbackSpeed.text
+
+        val isSelected = selectedSpeed == playbackSpeed.value
+        holder.itemView.isSelected = isSelected
+        holder.check.visibility = if (isSelected) View.VISIBLE else View.INVISIBLE
+
+        holder.itemView.setOnClickListener {
+            onItemClick(playbackSpeed)
+        }
+    }
+
+    override fun getItemCount(): Int = items.size
+}

--- a/player/src/main/java/com/tpstream/player/ui/adapter/PlaybackSpeedAdapter.kt
+++ b/player/src/main/java/com/tpstream/player/ui/adapter/PlaybackSpeedAdapter.kt
@@ -7,8 +7,8 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-import com.tpstream.player.R
 import com.tpstream.player.constants.PlaybackSpeed
+import com.tpstream.player.databinding.PlaybackSpeedListItemBinding
 
 internal class PlaybackSpeedAdapter(
     private val context: Context,
@@ -17,15 +17,16 @@ internal class PlaybackSpeedAdapter(
     private val onItemClick: (PlaybackSpeed) -> Unit
 ) : RecyclerView.Adapter<PlaybackSpeedAdapter.ViewHolder>() {
 
-    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val check: ImageView = itemView.findViewById(R.id.check)
-        val text: TextView = itemView.findViewById(R.id.text)
+    inner class ViewHolder(private val binding: PlaybackSpeedListItemBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+        val check: ImageView = binding.check
+        val text: TextView = binding.text
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view =
-            LayoutInflater.from(context).inflate(R.layout.playback_speed_list_item, parent, false)
-        return ViewHolder(view)
+        val binding =
+            PlaybackSpeedListItemBinding.inflate(LayoutInflater.from(context), parent, false)
+        return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
@@ -33,7 +34,6 @@ internal class PlaybackSpeedAdapter(
         holder.text.text = if (playbackSpeed.value == 1.0f) "Normal" else playbackSpeed.text
 
         val isSelected = selectedSpeed == playbackSpeed.value
-        holder.itemView.isSelected = isSelected
         holder.check.visibility = if (isSelected) View.VISIBLE else View.INVISIBLE
 
         holder.itemView.setOnClickListener {

--- a/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
@@ -6,6 +6,7 @@ internal typealias TimeBar = com.google.android.exoplayer2.ui.TimeBar
 internal typealias OnScrubListener = com.google.android.exoplayer2.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  com.google.android.exoplayer2.ui.StyledPlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = com.google.android.exoplayer2.ui.R.id
+internal typealias ControllerVisibilityListener = com.google.android.exoplayer2.ui.StyledPlayerView.ControllerVisibilityListener
 internal typealias DefaultTrackSelector = com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 internal typealias DefaultTrackSelectorParameters = com.google.android.exoplayer2.trackselection.DefaultTrackSelector.Parameters
 internal typealias TrackSelector = com.google.android.exoplayer2.trackselection.TrackSelector

--- a/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
@@ -7,6 +7,7 @@ internal typealias OnScrubListener = com.google.android.exoplayer2.ui.TimeBar.On
 internal typealias FullscreenButtonClickListener =  com.google.android.exoplayer2.ui.StyledPlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = com.google.android.exoplayer2.ui.R.id
 internal typealias ControllerVisibilityListener = com.google.android.exoplayer2.ui.StyledPlayerView.ControllerVisibilityListener
+internal typealias PlayerControlView = com.google.android.exoplayer2.ui.PlayerControlView
 internal typealias DefaultTrackSelector = com.google.android.exoplayer2.trackselection.DefaultTrackSelector
 internal typealias DefaultTrackSelectorParameters = com.google.android.exoplayer2.trackselection.DefaultTrackSelector.Parameters
 internal typealias TrackSelector = com.google.android.exoplayer2.trackselection.TrackSelector

--- a/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
@@ -7,6 +7,7 @@ internal typealias TimeBar = androidx.media3.ui.TimeBar
 internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
+internal typealias ExoplayerLayoutID = androidx.media3.ui.R.layout
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
@@ -8,6 +8,7 @@ internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
 internal typealias ControllerVisibilityListener = androidx.media3.ui.PlayerView.ControllerVisibilityListener
+internal typealias PlayerControlView = androidx.media3.ui.PlayerControlView
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
@@ -7,7 +7,6 @@ internal typealias TimeBar = androidx.media3.ui.TimeBar
 internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
-internal typealias ExoplayerLayoutID = androidx.media3.ui.R.layout
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
@@ -7,6 +7,7 @@ internal typealias TimeBar = androidx.media3.ui.TimeBar
 internal typealias OnScrubListener = androidx.media3.ui.TimeBar.OnScrubListener
 internal typealias FullscreenButtonClickListener =  androidx.media3.ui.PlayerView.FullscreenButtonClickListener
 internal typealias ExoplayerResourceID = androidx.media3.ui.R.id
+internal typealias ControllerVisibilityListener = androidx.media3.ui.PlayerView.ControllerVisibilityListener
 
 // androidx.media3.exoplayer.trackselection
 internal typealias DefaultTrackSelector = androidx.media3.exoplayer.trackselection.DefaultTrackSelector

--- a/player/src/main/player-mapping-files/layout/exo_player2_control_view.xml
+++ b/player/src/main/player-mapping-files/layout/exo_player2_control_view.xml
@@ -98,7 +98,7 @@
                 style="@style/ExoStyledControls.Button.Bottom.CC"/>
 
             <Button
-                android:id="@id/exo_playback_speed"
+                android:id="@+id/playback_speed"
                 style="@style/PlayBackSpeedButtonTheme"
                 android:layout_width="36dp"
                 android:layout_height="18dp"

--- a/player/src/main/player-mapping-files/layout/media3_player_control_view.xml
+++ b/player/src/main/player-mapping-files/layout/media3_player_control_view.xml
@@ -100,7 +100,7 @@
                 style="@style/ExoStyledControls.Button.Bottom.CC"/>
 
             <Button
-                android:id="@id/exo_playback_speed"
+                android:id="@+id/playback_speed"
                 style="@style/PlayBackSpeedButtonTheme"
                 android:layout_width="36dp"
                 android:layout_height="18dp"

--- a/player/src/main/res/layout/exo_player_control_view.xml
+++ b/player/src/main/res/layout/exo_player_control_view.xml
@@ -100,7 +100,7 @@
                 style="@style/ExoStyledControls.Button.Bottom.CC"/>
 
             <Button
-                android:id="@id/exo_playback_speed"
+                android:id="@+id/playback_speed"
                 style="@style/PlayBackSpeedButtonTheme"
                 android:layout_width="36dp"
                 android:layout_height="18dp"

--- a/player/src/main/res/layout/playback_speed_list_item.xml
+++ b/player/src/main/res/layout/playback_speed_list_item.xml
@@ -22,7 +22,7 @@
         android:layout_marginEnd="4dp"
         android:layout_marginRight="4dp"
         android:gravity="center|start"
-        android:textColor="#ffffff"
+        android:textColor="@color/tp_white"
         android:textSize="14sp"/>
 
 </LinearLayout>

--- a/player/src/main/res/layout/playback_speed_list_item.xml
+++ b/player/src/main/res/layout/playback_speed_list_item.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="150dp"
+    android:layout_height="52dp"
+    android:orientation="horizontal">
+
+    <ImageView
+        android:id="@+id/check"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginTop="12dp"
+        android:visibility="invisible"
+        android:src="@drawable/exo_styled_controls_check"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minHeight="52dp"
+        android:layout_marginEnd="4dp"
+        android:layout_marginRight="4dp"
+        android:gravity="center|start"
+        android:textColor="#ffffff"
+        android:textSize="14sp"/>
+
+</LinearLayout>

--- a/player/src/main/res/layout/popup_window_layout.xml
+++ b/player/src/main/res/layout/popup_window_layout.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/recycler_view"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    android:background="#B3000000"
+    android:scrollbars="vertical"
+    android:overScrollMode="always"/>
+

--- a/player/src/main/res/layout/popup_window_layout.xml
+++ b/player/src/main/res/layout/popup_window_layout.xml
@@ -3,8 +3,6 @@
     android:id="@+id/recycler_view"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="8dp"
     android:background="#B3000000"
     android:scrollbars="vertical"
-    android:overScrollMode="always"/>
-
+    android:scrollbarThumbVertical="@color/tp_white"/>


### PR DESCRIPTION
- In this commit, we added a custom playback speed option to the player view, including 1.75x speed, which was missing from the default ExoPlayer speeds.
- The existing playback speed selector from ExoPlayer has been disabled, and the custom speed options now provide more flexibility, including the `1.75x` speed setting.