### PR TITLE
fix: Filter duplicate codecs in the available codec list

### DIFF
--- a/player/src/main/java/com/tpstream/player/util/DeviceUtil.kt
+++ b/player/src/main/java/com/tpstream/player/util/DeviceUtil.kt
@@ -3,6 +3,7 @@ package com.tpstream.player.util
 import android.media.MediaCodecInfo
 import android.media.MediaCodecList
 import android.media.MediaFormat
+import android.os.Build
 import android.util.Log
 
 internal class DeviceUtil {
@@ -27,6 +28,7 @@ internal class DeviceUtil {
                 codecList.codecInfos
                     .filterNot { codecInfo -> codecInfo.isEncoder }
                     .filter { codecInfo -> MediaFormat.MIMETYPE_VIDEO_AVC in codecInfo.supportedTypes }
+                    .filter { codecInfo -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !codecInfo.isAlias }
                     .mapNotNull { it.toCodecDetails() }
             } catch (e: Exception) {
                 Log.d("DeviceUtils", "Error fetching codec capabilities: ${e.message}")

--- a/player/src/main/java/com/tpstream/player/util/DeviceUtil.kt
+++ b/player/src/main/java/com/tpstream/player/util/DeviceUtil.kt
@@ -28,7 +28,7 @@ internal class DeviceUtil {
                 codecList.codecInfos
                     .filterNot { codecInfo -> codecInfo.isEncoder }
                     .filter { codecInfo -> MediaFormat.MIMETYPE_VIDEO_AVC in codecInfo.supportedTypes }
-                    .filter { codecInfo -> Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !codecInfo.isAlias }
+                    .filter { codecInfo -> Build.VERSION.SDK_INT < Build.VERSION_CODES.Q || !codecInfo.isAlias  }
                     .mapNotNull { it.toCodecDetails() }
             } catch (e: Exception) {
                 Log.d("DeviceUtils", "Error fetching codec capabilities: ${e.message}")


### PR DESCRIPTION
- The `MediaCodecList` may contain duplicate entries for the same underlying codec represented by alternate codec names (aliases). In this commit, we filter the codec list using the isAlias method from MediaCodecInfo for Android SDK level 29 (Q) and above. We retain all codecs for lower versions since `MediaCodecList` does not return duplicates.