### PR TITLE
fix: Secure screen for L3 devices during DRM video playback

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -101,16 +101,18 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "lmsdemo"
                 provider = TPStreamsSDK.Provider.TestPress
             }
+            // https://app.tpstreams.com/embed/6eafqn/7RKQZj4gB2T/?access_token=d4986429-20e2-4b21-93ae-c70630a37e06
             "TPS_DRM" -> {
-                accessToken = "ab70caed-6168-497f-89c1-1e308da2c9aa"
-                videoId = "6suEBPy7EG4"
+                accessToken = "d4986429-20e2-4b21-93ae-c70630a37e06"
+                videoId = "7RKQZj4gB2T"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
+            // https://app.tpstreams.com/embed/6eafqn/98bPDTEfJeg/?access_token=80b313e3-0c1b-414d-9158-76af8f6fabb4
             "TPS_NON_DRM" -> {
-                accessToken = "48a481d0-7a7f-465f-9d18-86f52129430b"
-                videoId = "C65BJzhj48k"
-                orgCode = "dcek2m"
+                accessToken = "80b313e3-0c1b-414d-9158-76af8f6fabb4"
+                videoId = "98bPDTEfJeg"
+                orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -102,18 +102,16 @@ class PlayerActivity : AppCompatActivity() {
                 orgCode = "lmsdemo"
                 provider = TPStreamsSDK.Provider.TestPress
             }
-            // https://app.tpstreams.com/embed/6eafqn/7RKQZj4gB2T/?access_token=d4986429-20e2-4b21-93ae-c70630a37e06
             "TPS_DRM" -> {
-                accessToken = "d4986429-20e2-4b21-93ae-c70630a37e06"
-                videoId = "7RKQZj4gB2T"
+                accessToken = "ab70caed-6168-497f-89c1-1e308da2c9aa"
+                videoId = "6suEBPy7EG4"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
-            // https://app.tpstreams.com/embed/6eafqn/98bPDTEfJeg/?access_token=80b313e3-0c1b-414d-9158-76af8f6fabb4
             "TPS_NON_DRM" -> {
-                accessToken = "80b313e3-0c1b-414d-9158-76af8f6fabb4"
-                videoId = "98bPDTEfJeg"
-                orgCode = "6eafqn"
+                accessToken = "48a481d0-7a7f-465f-9d18-86f52129430b"
+                videoId = "C65BJzhj48k"
+                orgCode = "dcek2m"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
             null ->{}

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -32,6 +32,7 @@ class PlayerActivity : AppCompatActivity() {
         TPStreamsSDK.initialize(provider, orgCode)
         playerFragment =
             supportFragmentManager.findFragmentById(R.id.tpstream_player_fragment) as TpStreamPlayerFragment
+        playerFragment.enableSecureView()
         playerFragment.enableAutoFullScreenOnRotate()
         playerFragment.setOnInitializationListener(object: InitializationListener {
             override fun onInitializationSuccess(player: TpStreamPlayer) {

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -6,9 +6,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
-import androidx.media3.exoplayer.mediacodec.MediaCodecUtil
-import androidx.media3.exoplayer.util.EventLogger
+
 import com.google.common.collect.ImmutableList
 import com.tpstream.player.data.Asset
 import com.tpstream.player.data.AssetRepository
@@ -76,33 +74,9 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
     }
 
     private fun initializeExoplayer() {
-        val softwareOnlyCodecSelector = MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
-            // Select only software codecs by filtering out hardware-accelerated codecs
-
-            val mc = MediaCodecUtil.getDecoderInfos(
-                mimeType,
-                requiresSecureDecoder,
-                requiresTunnelingDecoder
-            )
-
-            if (mimeType.contains("avc")){
-                mc.filter { it.hardwareAccelerated && !it.name.contains("secure") }
-            } else {
-                mc
-            }
-
-        }
-
-
-        val renderersFactory = DefaultRenderersFactory(context)
-            //.setEnableDecoderFallback(true) // Allow fallback to software decoders.
-            //.setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)
-            .setMediaCodecSelector(softwareOnlyCodecSelector)
-
         exoPlayer = ExoPlayerBuilder(context)
             .setSeekForwardIncrementMs(context.resources.getString(R.string.tp_streams_player_seek_forward_increment_ms).toLong())
             .setSeekBackIncrementMs(context.resources.getString(R.string.tp_streams_player_seek_back_increment_ms).toLong())
-            .setRenderersFactory(renderersFactory)
             .build()
             .also { exoPlayer ->
                 exoPlayer.setAudioAttributes(AudioAttributes.DEFAULT, true)
@@ -119,7 +93,6 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
         assetRepository.getAsset(parameters, object : NetworkClient.TPResponse<Asset> {
             override fun onSuccess(result: Asset) {
                 asset = result
-                Log.d("TAG", "onSuccess: asset")
                 asset?.metadata = metadata
                 asset!!.getPlaybackURL()?.let {
                     playVideoInUIThread(it, parameters.startPositionInMilliSecs)
@@ -157,7 +130,6 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
         exoPlayer.trackSelectionParameters = getInitialTrackSelectionParameter()
         exoPlayer.seekTo(startPosition)
         exoPlayer.addAnalyticsListener(PlayerAnalyticsListener(this))
-        exoPlayer.addAnalyticsListener(EventLogger("TAG"))
         exoPlayer.prepare()
         tpStreamPlayerImplCallBack?.onPlayerPrepare()
     }

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -5,8 +5,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import android.util.Log
-
 import com.google.common.collect.ImmutableList
 import com.tpstream.player.data.Asset
 import com.tpstream.player.data.AssetRepository

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -7,7 +7,6 @@ import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.util.AttributeSet
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.SurfaceView
 import android.view.View
@@ -69,7 +68,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
         initializeViewModel()
         initializeNoticeScreen()
         setupPlayerControlsVisibilityListener()
-        Log.d("TAG", "TPStreamPlayerView: init")
     }
 
     private fun registerDownloadListener() {
@@ -84,12 +82,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
         resolutionButton?.setOnClickListener {
             onResolutionButtonClick()
         }
-    }
-
-    override fun onAttachedToWindow() {
-        //(playerView.videoSurfaceView as SurfaceView).setSecure(true)
-        Log.d("TAG", "onAttachedToWindow: ")
-        super.onAttachedToWindow()
     }
 
     private fun initializeViewModel() {

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -213,7 +213,6 @@ class TPStreamPlayerView @JvmOverloads constructor(
                 }
                 initializeSubtitleView()
                 updateSelectedResolution()
-                secureScreenForDRMVideo()
             }
         }
     }
@@ -235,14 +234,8 @@ class TPStreamPlayerView @JvmOverloads constructor(
         }
     }
 
-    private fun secureScreenForDRMVideo() {
-        if (player.asset == null) return
-        player.asset?.video?.isDrmProtected?.let {
-            Log.d("TAG", "secureScreenForDRMVideo: $it")
-            if (it) {
-                (playerView.videoSurfaceView as SurfaceView).setSecure(true)
-            }
-        }
+    internal fun setSecureSurfaceView() {
+        (playerView.videoSurfaceView as? SurfaceView)?.setSecure(true)
     }
 
     internal fun showPlayButton() {

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -7,7 +7,9 @@ import android.content.DialogInterface
 import android.content.res.ColorStateList
 import android.graphics.Color
 import android.util.AttributeSet
+import android.util.Log
 import android.view.LayoutInflater
+import android.view.SurfaceView
 import android.view.View
 import android.widget.*
 import androidx.annotation.ColorInt
@@ -67,6 +69,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
         initializeViewModel()
         initializeNoticeScreen()
         setupPlayerControlsVisibilityListener()
+        Log.d("TAG", "TPStreamPlayerView: init")
     }
 
     private fun registerDownloadListener() {
@@ -81,6 +84,12 @@ class TPStreamPlayerView @JvmOverloads constructor(
         resolutionButton?.setOnClickListener {
             onResolutionButtonClick()
         }
+    }
+
+    override fun onAttachedToWindow() {
+        //(playerView.videoSurfaceView as SurfaceView).setSecure(true)
+        Log.d("TAG", "onAttachedToWindow: ")
+        super.onAttachedToWindow()
     }
 
     private fun initializeViewModel() {
@@ -204,6 +213,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
                 }
                 initializeSubtitleView()
                 updateSelectedResolution()
+                secureScreenForDRMVideo()
             }
         }
     }
@@ -222,6 +232,16 @@ class TPStreamPlayerView @JvmOverloads constructor(
     private fun updateSelectedResolution() {
         player.params.initialResolutionHeight?.let {
             selectedResolution = ResolutionOptions.ADVANCED
+        }
+    }
+
+    private fun secureScreenForDRMVideo() {
+        if (player.asset == null) return
+        player.asset?.video?.isDrmProtected?.let {
+            Log.d("TAG", "secureScreenForDRMVideo: $it")
+            if (it) {
+                (playerView.videoSurfaceView as SurfaceView).setSecure(true)
+            }
         }
     }
 

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -41,6 +41,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private var assetApiCallCount = 0
     private var drmLicenseApiCallCount = 0
     private var offlineLicenseApiCallCount = 0
+    private var enableSecureView = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -58,6 +59,9 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         tpStreamPlayerView = viewBinding.tpStreamPlayerView
+        if (enableSecureView) {
+            tpStreamPlayerView.setSecureSurfaceView()
+        }
         tpStreamPlayerView.setTPStreamPlayerViewCallBack(tPStreamPlayerViewCallBack)
         registerFullScreenListener()
         DownloadCallback.invoke().callback = this
@@ -177,6 +181,10 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
             throw Exception("Player is not initialized yet. `load` method should be called onInitializationSuccess")
         }
         player?.load(parameters, metadata)
+    }
+
+    fun enableSecureView() {
+        enableSecureView = true
     }
 
     override fun onDownloadsSuccess(videoId: String?) {


### PR DESCRIPTION
- In this commit, we added a manual option to secure the view for L3 devices, as users on such devices can take screenshots or record the screen during DRM playback.
- By adding this feature, users will no longer be able to capture screenshots or screen recordings while DRM-protected content is being played.





