### PR TITLE
fix: Add BandwidthMeter to ExoPlayer for improved initial video resolution selection

### DIFF
--- a/player/src/main/java/com/tpstream/player/Mapping.kt
+++ b/player/src/main/java/com/tpstream/player/Mapping.kt
@@ -117,3 +117,7 @@ internal typealias Scheduler = androidx.media3.exoplayer.scheduler.Scheduler
 internal typealias DefaultMediaSourceFactory = androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 internal typealias MediaSource = androidx.media3.exoplayer.source.MediaSource
 internal typealias MediaSourceFactory = androidx.media3.exoplayer.source.MediaSource.Factory
+
+// androidx.media3.exoplayer.upstream
+internal typealias DefaultBandwidthMeter = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
+internal typealias DefaultBandwidthMeterBuilder = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter.Builder

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -75,10 +75,18 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
         exoPlayer = ExoPlayerBuilder(context)
             .setSeekForwardIncrementMs(context.resources.getString(R.string.tp_streams_player_seek_forward_increment_ms).toLong())
             .setSeekBackIncrementMs(context.resources.getString(R.string.tp_streams_player_seek_back_increment_ms).toLong())
+            .setBandwidthMeter(getBandwidthMeter())
             .build()
             .also { exoPlayer ->
                 exoPlayer.setAudioAttributes(AudioAttributes.DEFAULT, true)
             }
+    }
+
+    private fun getBandwidthMeter(): DefaultBandwidthMeter {
+        val initialBitrate = 200L * 1024L
+        return DefaultBandwidthMeterBuilder(context)
+            .setInitialBitrateEstimate(initialBitrate)
+            .build()
     }
 
     fun isParamsInitialized(): Boolean {

--- a/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
@@ -90,3 +90,5 @@ internal typealias ExoMediaDrmKeyRequest = com.google.android.exoplayer2.drm.Exo
 internal typealias ExoMediaDrmProvisionRequest = com.google.android.exoplayer2.drm.ExoMediaDrm.ProvisionRequest
 internal typealias DefaultDrmSessionManagerBuilder = com.google.android.exoplayer2.drm.DefaultDrmSessionManager.Builder
 internal typealias FrameworkMediaDrm = com.google.android.exoplayer2.drm.FrameworkMediaDrm
+internal typealias DefaultBandwidthMeter = com.google.android.exoplayer2.upstream.DefaultBandwidthMeter
+internal typealias DefaultBandwidthMeterBuilder = com.google.android.exoplayer2.upstream.DefaultBandwidthMeter.Builder

--- a/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
@@ -117,3 +117,7 @@ internal typealias Scheduler = androidx.media3.exoplayer.scheduler.Scheduler
 internal typealias DefaultMediaSourceFactory = androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 internal typealias MediaSource = androidx.media3.exoplayer.source.MediaSource
 internal typealias MediaSourceFactory = androidx.media3.exoplayer.source.MediaSource.Factory
+
+// androidx.media3.exoplayer.upstream
+internal typealias DefaultBandwidthMeter = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
+internal typealias DefaultBandwidthMeterBuilder = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter.Builder


### PR DESCRIPTION
- Previously, ExoPlayer selected the resolution based on internet speed, sometimes opting for a higher resolution than desired. This commit introduces a DefaultBandwidthMeter with an initial bitrate of 200 kbps, ensuring that ExoPlayer initially selects a track around this bitrate, which corresponds to a low resolution. The resolution will then adapt based on the actual internet speed.