### PR TITLE
fix: Add Custom Renderers Factory with Decoder Fallback to ExoPlayer

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -75,11 +75,17 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
         exoPlayer = ExoPlayerBuilder(context)
             .setSeekForwardIncrementMs(context.resources.getString(R.string.tp_streams_player_seek_forward_increment_ms).toLong())
             .setSeekBackIncrementMs(context.resources.getString(R.string.tp_streams_player_seek_back_increment_ms).toLong())
+            .setRenderersFactory(getRenderersFactory())
             .setBandwidthMeter(getBandwidthMeter())
             .build()
             .also { exoPlayer ->
                 exoPlayer.setAudioAttributes(AudioAttributes.DEFAULT, true)
             }
+    }
+
+    private fun getRenderersFactory(): DefaultRenderersFactory {
+        return DefaultRenderersFactory(context)
+            .setEnableDecoderFallback(true)
     }
 
     private fun getBandwidthMeter(): DefaultBandwidthMeter {


### PR DESCRIPTION
- This update introduces a new method, `getRenderersFactory()`, in the TpStreamPlayerImpl class to create a `DefaultRenderersFactory` with decoder fallback enabled. This enhancement is integrated into the `ExoPlayer` initialization, improving playback reliability by allowing the player to switch to alternative decoders when necessary