### PR TITLE
fix: Add option to enable Software Decoding

### DIFF
--- a/player/src/main/java/com/tpstream/player/Mapping.kt
+++ b/player/src/main/java/com/tpstream/player/Mapping.kt
@@ -121,3 +121,7 @@ internal typealias MediaSourceFactory = androidx.media3.exoplayer.source.MediaSo
 // androidx.media3.exoplayer.upstream
 internal typealias DefaultBandwidthMeter = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 internal typealias DefaultBandwidthMeterBuilder = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter.Builder
+
+// androidx.media3.exoplayer.mediacodec
+internal typealias MediaCodecSelector = androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+internal typealias MediaCodecUtil = androidx.media3.exoplayer.mediacodec.MediaCodecUtil

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -5,8 +5,6 @@ import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
-import androidx.media3.exoplayer.mediacodec.MediaCodecUtil
 import com.google.common.collect.ImmutableList
 import com.tpstream.player.data.Asset
 import com.tpstream.player.data.AssetRepository

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -42,6 +42,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private var drmLicenseApiCallCount = 0
     private var offlineLicenseApiCallCount = 0
     private var enableSecureView = false
+    private var useSoftwareDecoder = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -165,6 +166,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
 
     private fun initializePlayer() {
         player = TpStreamPlayerImpl(requireContext())
+        player.init(useSoftwareDecoder)
         player.setTpStreamPlayerImplCallBack(tpStreamPlayerImplCallBack)
         tpStreamPlayerView.setPlayer(player)
         player.exoPlayer.addListener(_playbackStateListener)
@@ -185,6 +187,10 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
 
     fun enableSecureView() {
         enableSecureView = true
+    }
+
+    fun useSoftwareDecoder() {
+        useSoftwareDecoder = true
     }
 
     override fun onDownloadsSuccess(videoId: String?) {

--- a/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/ExoPlayer2Mapping.kt
@@ -92,3 +92,5 @@ internal typealias DefaultDrmSessionManagerBuilder = com.google.android.exoplaye
 internal typealias FrameworkMediaDrm = com.google.android.exoplayer2.drm.FrameworkMediaDrm
 internal typealias DefaultBandwidthMeter = com.google.android.exoplayer2.upstream.DefaultBandwidthMeter
 internal typealias DefaultBandwidthMeterBuilder = com.google.android.exoplayer2.upstream.DefaultBandwidthMeter.Builder
+internal typealias MediaCodecSelector = com.google.android.exoplayer2.mediacodec.MediaCodecSelector
+internal typealias MediaCodecUtil = com.google.android.exoplayer2.mediacodec.MediaCodecUtil

--- a/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
+++ b/player/src/main/player-mapping-files/kotlin/Media3PlayerMapping.kt
@@ -121,3 +121,7 @@ internal typealias MediaSourceFactory = androidx.media3.exoplayer.source.MediaSo
 // androidx.media3.exoplayer.upstream
 internal typealias DefaultBandwidthMeter = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 internal typealias DefaultBandwidthMeterBuilder = androidx.media3.exoplayer.upstream.DefaultBandwidthMeter.Builder
+
+// androidx.media3.exoplayer.mediacodec
+internal typealias MediaCodecSelector = androidx.media3.exoplayer.mediacodec.MediaCodecSelector
+internal typealias MediaCodecUtil = androidx.media3.exoplayer.mediacodec.MediaCodecUtil


### PR DESCRIPTION
- This update introduces a `useSoftwareDecoder` flag in `TpStreamPlayerImpl` to allow for software decoding during ExoPlayer initialization. The `init()` method is modified to accept this flag, and the `getRenderersFactory()` method configures a custom `MediaCodecSelector` to filter for software-only codecs when enabled. Additionally, `TpStreamPlayerFragment` is updated to pass this option during player setup, enhancing playback flexibility across devices.