### PR TITLE
fix: Update Target SDK version in app module

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'com.tpstream.app'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.tpstream.app"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/tpstream/app/MainActivity.kt
+++ b/app/src/main/java/com/tpstream/app/MainActivity.kt
@@ -1,17 +1,23 @@
 package com.tpstream.app
 
 import android.content.Intent
+import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.os.Build
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.view.View
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import com.tpstream.player.TPStreamsSDK
 import com.tpstream.player.TpInitParams
+import android.Manifest.permission.POST_NOTIFICATIONS
 import com.tpstream.player.offline.TpStreamDownloadManager
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        askPushNotificationPermission()
     }
 
     fun buttonClick(view: View) {
@@ -58,4 +64,19 @@ class MainActivity : AppCompatActivity() {
         TpStreamDownloadManager(applicationContext).startDownload(this,parameters)
     }
 
+    private fun askPushNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(
+                    this,
+                    POST_NOTIFICATIONS
+                ) != PERMISSION_GRANTED
+            ) {
+                ActivityCompat.requestPermissions(
+                    this,
+                    arrayOf(POST_NOTIFICATIONS),
+                    1000
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
- Updated the target and compile SDK version from 33 to 34 in the app module.
Added runtime permission request for push notifications for Android 13 and above to comply with new requirements.