### PR TITLE
fix: Add parameter initialization validation to prevent crashes

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -221,6 +221,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
     }
 
     private fun updateSelectedResolution() {
+        if (!player.isParamsInitialized()) return
         player.params.initialResolutionHeight?.let {
             selectedResolution = ResolutionOptions.ADVANCED
         }


### PR DESCRIPTION
- Ensure player parameters are properly initialized before updating the selected resolution to avoid crashes in edge cases. Added `isParamsInitialized()` check for validation.