### PR TITLE
fix: Show download media size from API response

### DIFF
--- a/player/src/main/java/com/tpstream/player/data/Asset.kt
+++ b/player/src/main/java/com/tpstream/player/data/Asset.kt
@@ -137,5 +137,13 @@ data class Track(
     val name: String,
     val url: String,
     val language: String,
-    val duration: Long
+    val duration: Long,
+    val playlists: List<Playlist>
+)
+
+data class Playlist(
+    val name: String,
+    val bytes: Long,
+    val width: Int,
+    val height: Int
 )

--- a/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
+++ b/player/src/main/java/com/tpstream/player/data/AssetModelMapping.kt
@@ -92,6 +92,18 @@ internal fun TPStreamsNetworkAsset.asDomainAsset(): Asset {
         }
     }
 
+    fun TPStreamsNetworkAsset.Video.Track.getPlayLists(): List<Playlist> {
+        if (this.playlists.isNullOrEmpty()) return listOf()
+        return this.playlists.map { playlist ->
+            Playlist(
+                playlist.name ?: "",
+                playlist.bytes ?: 0,
+                playlist.width ?: 0,
+                playlist.height ?: 0
+            )
+        }
+    }
+
     fun getVideoTracks(): List<Track>? {
         return this.video?.tracks?.map { track ->
             Track(
@@ -99,7 +111,8 @@ internal fun TPStreamsNetworkAsset.asDomainAsset(): Asset {
                 track.name ?: "",
                 track.url ?: "",
                 track.language ?: "",
-                track.duration ?: 0
+                track.duration ?: 0,
+                track.getPlayLists()
             )
         }
     }

--- a/player/src/main/java/com/tpstream/player/data/source/network/TPStreamsNetworkAsset.kt
+++ b/player/src/main/java/com/tpstream/player/data/source/network/TPStreamsNetworkAsset.kt
@@ -26,7 +26,15 @@ data class TPStreamsNetworkAsset(
             @SerializedName("url") val url: String?,
             @SerializedName("language") val language: String?,
             @SerializedName("duration") val duration: Long?,
-        )
+            @SerializedName("playlists") val playlists: List<Playlist>?
+        ) {
+            data class Playlist(
+                @SerializedName("name") val name: String?,
+                @SerializedName("bytes") val bytes: Long?,
+                @SerializedName("width") val width: Int?,
+                @SerializedName("height") val height: Int?
+            )
+        }
     }
 
     data class LiveStream(

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -233,7 +233,6 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
         private fun getTotalMediaSize(trackInfo: TrackInfo): String {
             val track = asset.video.tracks?.firstOrNull { it.type == "Playlist" }
             val playlistSize = getPlaylistSize(track, trackInfo)
-            Log.d("TAG", "getTotalMediaSize: $playlistSize")
             val size = playlistSize ?: (getVideoSizeInMB(trackInfo) + getAudioSizeInMB(trackInfo))
             return "$size MB"
         }

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -2,6 +2,7 @@ package com.tpstream.player.ui
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -232,6 +233,7 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
         private fun getTotalMediaSize(trackInfo: TrackInfo): String {
             val track = asset.video.tracks?.firstOrNull { it.type == "Playlist" }
             val playlistSize = getPlaylistSize(track, trackInfo)
+            Log.d("TAG", "getTotalMediaSize: $playlistSize")
             val size = playlistSize ?: (getVideoSizeInMB(trackInfo) + getAudioSizeInMB(trackInfo))
             return "$size MB"
         }
@@ -246,7 +248,7 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
                     }
                 }
                 ?.firstOrNull { it.height == trackInfo.videoFormat.height }
-                ?.bytes?.let { it / 1024L / 1024L }
+                ?.bytes?.let { (it / 1024L) / 1024L }
         }
 
         private fun getVideoSizeInMB(trackInfo: TrackInfo): Int {

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -17,6 +17,8 @@ import com.tpstream.player.*
 import com.tpstream.player.R
 import com.tpstream.player.databinding.TpDownloadTrackSelectionDialogBinding
 import com.tpstream.player.data.Asset
+import com.tpstream.player.data.Track
+import com.tpstream.player.data.source.network.TPStreamsNetworkAsset
 import com.tpstream.player.offline.VideoDownloadRequestCreationHandler
 import com.tpstream.player.util.DeviceUtil
 import okio.IOException
@@ -229,13 +231,22 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
 
         private fun getTotalMediaSize(trackInfo: TrackInfo): String {
             val track = asset.video.tracks?.firstOrNull { it.type == "Playlist" }
-
-            val playlistSize = track?.playlists
-                ?.firstOrNull { it.height == trackInfo.videoFormat.height }
-                ?.bytes?.let { it / 1024L / 1024L }
-
+            val playlistSize = getPlaylistSize(track, trackInfo)
             val size = playlistSize ?: (getVideoSizeInMB(trackInfo) + getAudioSizeInMB(trackInfo))
             return "$size MB"
+        }
+
+        private fun getPlaylistSize(track: Track?, trackInfo: TrackInfo): Long? {
+            return track?.playlists
+                ?.filter { // Filter based on DRM protection
+                    if (asset.video.isDrmProtected == true) {
+                        it.name.contains("dash")
+                    } else {
+                        true // No filtering for non-DRM, allow all playlists
+                    }
+                }
+                ?.firstOrNull { it.height == trackInfo.videoFormat.height }
+                ?.bytes?.let { it / 1024L / 1024L }
         }
 
         private fun getVideoSizeInMB(trackInfo: TrackInfo): Int {

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -228,7 +228,14 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
         }
 
         private fun getTotalMediaSize(trackInfo: TrackInfo): String {
-            return "${(getVideoSizeInMB(trackInfo) + getAudioSizeInMB(trackInfo))} MB"
+            val track = asset.video.tracks?.firstOrNull { it.type == "Playlist" }
+
+            val playlistSize = track?.playlists
+                ?.firstOrNull { it.height == trackInfo.videoFormat.height }
+                ?.bytes?.let { it / 1024L / 1024L }
+
+            val size = playlistSize ?: (getVideoSizeInMB(trackInfo) + getAudioSizeInMB(trackInfo))
+            return "$size MB"
         }
 
         private fun getVideoSizeInMB(trackInfo: TrackInfo): Int {

--- a/player/src/test/java/com/tpstream/player/AssetModelMappingTest.kt
+++ b/player/src/test/java/com/tpstream/player/AssetModelMappingTest.kt
@@ -29,7 +29,17 @@ class AssetModelMappingTest {
                         name = "English",
                         url = "http://example.com/track_en.vtt",
                         language = "en",
-                        duration = 300L
+                        duration = 300L,
+                        playlists = listOf()
+                    ),
+                    TPStreamsNetworkAsset.Video.Track(
+                        id = 1,
+                        type = "Playlist",
+                        name = null,
+                        url = null,
+                        language = null,
+                        duration = null,
+                        playlists = getPlaylist()
                     )
                 ),
                 duration = 3600L
@@ -57,13 +67,53 @@ class AssetModelMappingTest {
         assertEquals("http://example.com/dash", domainAsset.video.url)
         assertEquals(3600L, domainAsset.video.duration)
         assertEquals("Completed", domainAsset.video.transcodingStatus)
-        assertEquals(1, domainAsset.video.tracks?.size)
+        assertEquals(2, domainAsset.video.tracks?.size)
         assertEquals("subtitles", domainAsset.video.tracks?.get(0)?.type)
         assertEquals("http://example.com/thumbnail.jpg", domainAsset.thumbnail)
         assertEquals("http://example.com/live", domainAsset.liveStream?.url)
         assertEquals("Streaming", domainAsset.liveStream?.status)
         assertEquals("folder1/folder2", domainAsset.folderTree)
+        assertEquals(6,domainAsset.video.tracks?.first { it.type == "Playlist" }?.playlists?.size)
     }
+
+    private fun getPlaylist() = listOf(
+        TPStreamsNetworkAsset.Video.Track.Playlist(
+            name = "4k",
+            bytes = 291433715,
+            width = 3840,
+            height = 2160
+        ),
+        TPStreamsNetworkAsset.Video.Track.Playlist(
+            name = "1080p",
+            bytes = 143993774,
+            width = 1920,
+            height = 1080
+        ),
+        TPStreamsNetworkAsset.Video.Track.Playlist(
+            name = "240p",
+            bytes = 19372332,
+            width = 426,
+            height = 240
+        ),
+        TPStreamsNetworkAsset.Video.Track.Playlist(
+            name = "360p",
+            bytes = 29839983,
+            width = 640,
+            height = 360
+        ),
+        TPStreamsNetworkAsset.Video.Track.Playlist(
+            name = "480p",
+            bytes = 42297052,
+            width = 854,
+            height = 480
+        ),
+        TPStreamsNetworkAsset.Video.Track.Playlist(
+            name = "720p",
+            bytes = 70430690,
+            width = 1280,
+            height = 720
+        )
+    )
 
     @Test
     fun `test TestpressNetworkAsset to Asset Mapping`() {

--- a/player/src/test/java/com/tpstream/player/TPStreamsNetworkAssetTest.kt
+++ b/player/src/test/java/com/tpstream/player/TPStreamsNetworkAssetTest.kt
@@ -81,6 +81,16 @@ class TPStreamsNetworkAssetTest {
         assertEquals(liveStream?.chatEmbedUrl, "https://app.tpstreams.com/live-chat/6eafqn/AQ3FFGFKq3g/")
         assertEquals(liveStream?.enableDrm, false)
         assertEquals(liveStream?.noticeMessage, "The live stream has come to an end. Stay tuned, we'll have the recording ready for you shortly.")
+
+        // Assertions for tracks
+        val tracks = video?.tracks
+        assertEquals(tracks?.size, 2)
+        assertEquals(tracks?.filter { it.type == "Preview Thumbnail"}?.size, 1)
+        assertEquals(tracks?.filter { it.type == "Playlist"}?.size, 1)
+
+        // Assertions for Playlist
+        val playlists = tracks?.filter { it.type == "Playlist" }
+        assertEquals(playlists?.size, 6)
     }
 
     @Test
@@ -98,37 +108,32 @@ class TPStreamsNetworkAssetTest {
     private fun getTpStreamsAssetJSON(): String {
         return """
                 {
-                    "title": "Raj 5",
+                    "title": "manifest.mp4",
                     "bytes": null,
-                    "type": "livestream",
+                    "type": "video",
                     "video": {
                         "progress": 0,
-                        "thumbnails": [
-                            "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_4.png",
-                            "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_6.png",
-                            "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_5.png",
-                            "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_2.png",
-                            "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_1.png",
-                            "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_3.png"
-                        ],
+                        "thumbnails": null,
                         "status": "Completed",
-                        "playback_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/video.m3u8",
-                        "dash_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/video.mpd",
-                        "preview_thumbnail_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_4.png",
-                        "cover_thumbnail_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_4.png",
+                        "playback_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/72c9RRHj3M8/video.m3u8",
+                        "dash_url": null,
+                        "preview_thumbnail_url": null,
+                        "cover_thumbnail_url": null,
                         "format": "abr",
                         "resolutions": [
-                            "240p",
-                            "360p",
+                            "720p",
                             "480p",
-                            "720p"
+                            "360p",
+                            "240p",
+                            "1080p",
+                            "4k"
                         ],
                         "video_codec": "h264",
                         "audio_codec": "aac",
-                        "enable_drm": true,
+                        "enable_drm": false,
                         "tracks": [
                             {
-                                "id": 66268,
+                                "id": 134222,
                                 "type": "Preview Thumbnail",
                                 "name": "",
                                 "url": "https://d384padtbeqfgy.cloudfront.net/None",
@@ -141,54 +146,90 @@ class TPStreamsNetworkAssetTest {
                                 "playlists": [],
                                 "subtitle_type": "Uploaded",
                                 "preview_thumbnail": {
-                                    "url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/sprite/sprite_image.png",
-                                    "interval": 1,
+                                    "url": "https://d384padtbeqfgy.cloudfront.net/transcoded/72c9RRHj3M8/sprite/sprite_image.png",
+                                    "interval": 2,
                                     "width": 160,
                                     "height": 90,
-                                    "rows": 12,
-                                    "columns": 12
+                                    "rows": 18,
+                                    "columns": 18
                                 }
+                            },
+                            {
+                                "id": 134229,
+                                "type": "Playlist",
+                                "name": "",
+                                "url": "https://d384padtbeqfgy.cloudfront.net/None",
+                                "bytes": null,
+                                "language": "en",
+                                "width": null,
+                                "height": null,
+                                "duration": null,
+                                "is_active": true,
+                                "playlists": [
+                                    {
+                                        "name": "4k",
+                                        "bytes": 291433715,
+                                        "width": 3840,
+                                        "height": 2160
+                                    },
+                                    {
+                                        "name": "1080p",
+                                        "bytes": 143993774,
+                                        "width": 1920,
+                                        "height": 1080
+                                    },
+                                    {
+                                        "name": "240p",
+                                        "bytes": 19372332,
+                                        "width": 426,
+                                        "height": 240
+                                    },
+                                    {
+                                        "name": "360p",
+                                        "bytes": 29839983,
+                                        "width": 640,
+                                        "height": 360
+                                    },
+                                    {
+                                        "name": "480p",
+                                        "bytes": 42297052,
+                                        "width": 854,
+                                        "height": 480
+                                    },
+                                    {
+                                        "name": "720p",
+                                        "bytes": 70430690,
+                                        "width": 1280,
+                                        "height": 720
+                                    }
+                                ],
+                                "subtitle_type": "Uploaded",
+                                "preview_thumbnail": null
                             }
                         ],
                         "inputs": [
                             {
-                                "url": "private/AQ3FFGFKq3g/video.mp4"
+                                "url": "private/cd928dc3384d4d4db9f32f4597862296.mp4"
                             }
                         ],
                         "transmux_only": null,
-                        "duration": 139,
-                        "content_protection_type": "drm",
+                        "duration": 635,
+                        "content_protection_type": "disabled",
                         "generate_subtitle": false
                     },
-                    "id": "AQ3FFGFKq3g",
-                    "live_stream": {
-                        "rtmp_url": "rtmp://65.2.80.123/live",
-                        "stream_key": "org-6eafqn-live-AQ3FFGFKq3g-EDZu",
-                        "status": "Completed",
-                        "hls_url": "https://d384padtbeqfgy.cloudfront.net/live/6eafqn/AQ3FFGFKq3g/video.m3u8",
-                        "start": "2024-07-15 11:53:06",
-                        "transcode_recorded_video": true,
-                        "enable_drm_for_recording": true,
-                        "chat_embed_url": "https://app.tpstreams.com/live-chat/6eafqn/AQ3FFGFKq3g/",
-                        "chat_room_id": "321d94c3-9434-4515-8af8-9b003b96501d",
-                        "resolutions": [
-                            "240p",
-                            "480p",
-                            "720p"
-                        ],
-                        "enable_drm": false,
-                        "enable_llhls": false,
-                        "latency": "Low Latency",
-                        "notice_message": "The live stream has come to an end. Stay tuned, we'll have the recording ready for you shortly."
+                    "id": "72c9RRHj3M8",
+                    "live_stream": null,
+                    "parent": {
+                        "title": "NON-DRM",
+                        "uuid": "5gJhaaBKZBK"
                     },
-                    "parent": null,
-                    "parent_id": null,
-                    "views_count": 1,
+                    "parent_id": "5gJhaaBKZBK",
+                    "views_count": 0,
                     "average_watched_time": 0,
                     "total_watch_time": 0,
-                    "unique_viewers_count": 1,
-                    "download_url": "https://d384padtbeqfgy.cloudfront.net/private/AQ3FFGFKq3g/video.mp4?response-content-disposition=attachment%3B+filename%3DRaj+5.mp4&Expires=1727357416&Signature=2GdFCD40ia3oCOxFFPfBPlNoTot7s7gCbdHjTuy5DuMxO1fEIu3QlxmJUS1A0oCVklu1t-jl59b7jlYb1ZMdbdgWJ7~9pidlo8ctPSKGXxGvzm~22TGCesovkFDw8tglUmsFif~lfrUarIzprIfew~CRntg5vWJuCuL~zKXjmyDZ6Z9TXmJwdziqHJLCoNzI3hZUWROhBV6MGnxyUuKqXamn6OuoF7vGTJglV4Bc~miAiHi1Y3DOavGNke7QvoJ4jR7W3C9CabWzYTybBKQRCvYShR3IiH75WNyqq2KGh6ymsA72pRLijYEndgzNQ8Zkt7oLxlNy6tEnry8472CQyQ__&Key-Pair-Id=K2XWKDWM065EGO",
-                    "folder_tree": ""
+                    "unique_viewers_count": 0,
+                    "download_url": "https://d384padtbeqfgy.cloudfront.net/private/cd928dc3384d4d4db9f32f4597862296.mp4?response-content-disposition=attachment%3B+filename%3Dmanifest.mp4&Expires=1727379627&Signature=aSkGYh6nB4xHVGpyqQ60262hgE8kwJiNoK64xEOnvhVdWkIygJrgj8uk5AndWwj86ig8Q-SrkOls6PjHQl6nlpPG8stm763ozTRczo2VuLVpQrUF1wD0Y6-Ni2F-5-FEYB1rWYXR9R0WY0Cg8y0m0uhLTiAlKSwgeSAasIeV-5l-qFLxNrcjJR8WqvUQ6z8LiFB51aR2Nr8Nr91LnDYk9bidzw1Xzo9xxsMazUvFoGqRLxZ8TGycIFrK-xPbSqZJIngWNEkT0rqS9WO~QzBgFylKcA7iydOoQhkajtFq1jspVmbNWwc7OB0~RAxT4a6p3gzaPdhJRSjkDyF8j6JTiA__&Key-Pair-Id=K2XWKDWM065EGO",
+                    "folder_tree": "NON-DRM"
                 }
         """.trimIndent()
     }

--- a/player/src/test/java/com/tpstream/player/TPStreamsNetworkAssetTest.kt
+++ b/player/src/test/java/com/tpstream/player/TPStreamsNetworkAssetTest.kt
@@ -89,8 +89,9 @@ class TPStreamsNetworkAssetTest {
         assertEquals(tracks?.filter { it.type == "Playlist"}?.size, 1)
 
         // Assertions for Playlist
-        val playlists = tracks?.filter { it.type == "Playlist" }
-        assertEquals(playlists?.size, 6)
+        val playlists = tracks?.filter { it.type == "Playlist" }?.first()?.playlists
+        assertEquals(playlists?.size, 8)
+        assertEquals(playlists?.filter { it.name?.contains("dash") == true }?.size, 4)
     }
 
     @Test
@@ -107,130 +108,163 @@ class TPStreamsNetworkAssetTest {
 
     private fun getTpStreamsAssetJSON(): String {
         return """
-                {
-                    "title": "manifest.mp4",
-                    "bytes": null,
-                    "type": "video",
-                    "video": {
-                        "progress": 0,
-                        "thumbnails": null,
-                        "status": "Completed",
-                        "playback_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/72c9RRHj3M8/video.m3u8",
-                        "dash_url": null,
-                        "preview_thumbnail_url": null,
-                        "cover_thumbnail_url": null,
-                        "format": "abr",
-                        "resolutions": [
-                            "720p",
-                            "480p",
-                            "360p",
-                            "240p",
-                            "1080p",
-                            "4k"
-                        ],
-                        "video_codec": "h264",
-                        "audio_codec": "aac",
-                        "enable_drm": false,
-                        "tracks": [
-                            {
-                                "id": 134222,
-                                "type": "Preview Thumbnail",
-                                "name": "",
-                                "url": "https://d384padtbeqfgy.cloudfront.net/None",
-                                "bytes": null,
-                                "language": "en",
-                                "width": null,
-                                "height": null,
-                                "duration": null,
-                                "is_active": true,
-                                "playlists": [],
-                                "subtitle_type": "Uploaded",
-                                "preview_thumbnail": {
-                                    "url": "https://d384padtbeqfgy.cloudfront.net/transcoded/72c9RRHj3M8/sprite/sprite_image.png",
-                                    "interval": 2,
-                                    "width": 160,
-                                    "height": 90,
-                                    "rows": 18,
-                                    "columns": 18
+            {
+                "title": "Raj 5",
+                "bytes": null,
+                "type": "livestream",
+                "video": {
+                    "progress": 0,
+                    "thumbnails": [
+                        "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_4.png",
+                        "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_6.png",
+                        "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_5.png",
+                        "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_2.png",
+                        "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_1.png",
+                        "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_3.png"
+                    ],
+                    "status": "Completed",
+                    "playback_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/video.m3u8",
+                    "dash_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/video.mpd",
+                    "preview_thumbnail_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_4.png",
+                    "cover_thumbnail_url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/thumbnails/thumbnail_4.png",
+                    "format": "abr",
+                    "resolutions": [
+                        "240p",
+                        "360p",
+                        "480p",
+                        "720p"
+                    ],
+                    "video_codec": "h264",
+                    "audio_codec": "aac",
+                    "enable_drm": true,
+                    "tracks": [
+                        {
+                            "id": 66268,
+                            "type": "Preview Thumbnail",
+                            "name": "",
+                            "url": "https://d384padtbeqfgy.cloudfront.net/None",
+                            "bytes": null,
+                            "language": "en",
+                            "width": null,
+                            "height": null,
+                            "duration": null,
+                            "is_active": true,
+                            "playlists": [],
+                            "subtitle_type": "Uploaded",
+                            "preview_thumbnail": {
+                                "url": "https://d384padtbeqfgy.cloudfront.net/transcoded/AQ3FFGFKq3g/sprite/sprite_image.png",
+                                "interval": 1,
+                                "width": 160,
+                                "height": 90,
+                                "rows": 12,
+                                "columns": 12
+                            }
+                        },
+                        {
+                            "id": 140814,
+                            "type": "Playlist",
+                            "name": "",
+                            "url": "https://d384padtbeqfgy.cloudfront.net/None",
+                            "bytes": null,
+                            "language": "en",
+                            "width": null,
+                            "height": null,
+                            "duration": null,
+                            "is_active": true,
+                            "playlists": [
+                                {
+                                    "name": "720p_dash",
+                                    "bytes": 717601,
+                                    "width": 1280,
+                                    "height": 720
+                                },
+                                {
+                                    "name": "720p_hls",
+                                    "bytes": 655730,
+                                    "width": 1280,
+                                    "height": 720
+                                },
+                                {
+                                    "name": "480p_dash",
+                                    "bytes": 520776,
+                                    "width": 854,
+                                    "height": 480
+                                },
+                                {
+                                    "name": "480p_hls",
+                                    "bytes": 458855,
+                                    "width": 854,
+                                    "height": 480
+                                },
+                                {
+                                    "name": "360p_dash",
+                                    "bytes": 445145,
+                                    "width": 640,
+                                    "height": 360
+                                },
+                                {
+                                    "name": "360p_hls",
+                                    "bytes": 383270,
+                                    "width": 640,
+                                    "height": 360
+                                },
+                                {
+                                    "name": "240p_dash",
+                                    "bytes": 360381,
+                                    "width": 426,
+                                    "height": 240
+                                },
+                                {
+                                    "name": "240p_hls",
+                                    "bytes": 298466,
+                                    "width": 426,
+                                    "height": 240
                                 }
-                            },
-                            {
-                                "id": 134229,
-                                "type": "Playlist",
-                                "name": "",
-                                "url": "https://d384padtbeqfgy.cloudfront.net/None",
-                                "bytes": null,
-                                "language": "en",
-                                "width": null,
-                                "height": null,
-                                "duration": null,
-                                "is_active": true,
-                                "playlists": [
-                                    {
-                                        "name": "4k",
-                                        "bytes": 291433715,
-                                        "width": 3840,
-                                        "height": 2160
-                                    },
-                                    {
-                                        "name": "1080p",
-                                        "bytes": 143993774,
-                                        "width": 1920,
-                                        "height": 1080
-                                    },
-                                    {
-                                        "name": "240p",
-                                        "bytes": 19372332,
-                                        "width": 426,
-                                        "height": 240
-                                    },
-                                    {
-                                        "name": "360p",
-                                        "bytes": 29839983,
-                                        "width": 640,
-                                        "height": 360
-                                    },
-                                    {
-                                        "name": "480p",
-                                        "bytes": 42297052,
-                                        "width": 854,
-                                        "height": 480
-                                    },
-                                    {
-                                        "name": "720p",
-                                        "bytes": 70430690,
-                                        "width": 1280,
-                                        "height": 720
-                                    }
-                                ],
-                                "subtitle_type": "Uploaded",
-                                "preview_thumbnail": null
-                            }
-                        ],
-                        "inputs": [
-                            {
-                                "url": "private/cd928dc3384d4d4db9f32f4597862296.mp4"
-                            }
-                        ],
-                        "transmux_only": null,
-                        "duration": 635,
-                        "content_protection_type": "disabled",
-                        "generate_subtitle": false
-                    },
-                    "id": "72c9RRHj3M8",
-                    "live_stream": null,
-                    "parent": {
-                        "title": "NON-DRM",
-                        "uuid": "5gJhaaBKZBK"
-                    },
-                    "parent_id": "5gJhaaBKZBK",
-                    "views_count": 0,
-                    "average_watched_time": 0,
-                    "total_watch_time": 0,
-                    "unique_viewers_count": 0,
-                    "download_url": "https://d384padtbeqfgy.cloudfront.net/private/cd928dc3384d4d4db9f32f4597862296.mp4?response-content-disposition=attachment%3B+filename%3Dmanifest.mp4&Expires=1727379627&Signature=aSkGYh6nB4xHVGpyqQ60262hgE8kwJiNoK64xEOnvhVdWkIygJrgj8uk5AndWwj86ig8Q-SrkOls6PjHQl6nlpPG8stm763ozTRczo2VuLVpQrUF1wD0Y6-Ni2F-5-FEYB1rWYXR9R0WY0Cg8y0m0uhLTiAlKSwgeSAasIeV-5l-qFLxNrcjJR8WqvUQ6z8LiFB51aR2Nr8Nr91LnDYk9bidzw1Xzo9xxsMazUvFoGqRLxZ8TGycIFrK-xPbSqZJIngWNEkT0rqS9WO~QzBgFylKcA7iydOoQhkajtFq1jspVmbNWwc7OB0~RAxT4a6p3gzaPdhJRSjkDyF8j6JTiA__&Key-Pair-Id=K2XWKDWM065EGO",
-                    "folder_tree": "NON-DRM"
-                }
+                            ],
+                            "subtitle_type": "Uploaded",
+                            "preview_thumbnail": null
+                        }
+                    ],
+                    "inputs": [
+                        {
+                            "url": "private/AQ3FFGFKq3g/video.mp4"
+                        }
+                    ],
+                    "transmux_only": null,
+                    "duration": 139,
+                    "content_protection_type": "drm",
+                    "generate_subtitle": false
+                },
+                "id": "AQ3FFGFKq3g",
+                "live_stream": {
+                    "rtmp_url": "rtmp://65.2.80.123/live",
+                    "stream_key": "org-6eafqn-live-AQ3FFGFKq3g-EDZu",
+                    "status": "Completed",
+                    "hls_url": "https://d384padtbeqfgy.cloudfront.net/live/6eafqn/AQ3FFGFKq3g/video.m3u8",
+                    "start": "2024-07-15 11:53:06",
+                    "transcode_recorded_video": true,
+                    "enable_drm_for_recording": true,
+                    "chat_embed_url": "https://app.tpstreams.com/live-chat/6eafqn/AQ3FFGFKq3g/",
+                    "chat_room_id": "321d94c3-9434-4515-8af8-9b003b96501d",
+                    "resolutions": [
+                        "240p",
+                        "480p",
+                        "720p"
+                    ],
+                    "enable_drm": false,
+                    "enable_llhls": false,
+                    "latency": "Low Latency",
+                    "notice_message": "The live stream has come to an end. Stay tuned, we'll have the recording ready for you shortly."
+                },
+                "parent": null,
+                "parent_id": null,
+                "views_count": 1,
+                "average_watched_time": 0,
+                "total_watch_time": 0,
+                "unique_viewers_count": 1,
+                "download_url": "https://d384padtbeqfgy.cloudfront.net/private/AQ3FFGFKq3g/video.mp4?response-content-disposition=attachment%3B+filename%3DRaj+5.mp4&Expires=1727445631&Signature=ypGs92LcP6x6SLhrgF4mjuSzSiaFvaBKgYKWYalkqVZbovWEetXWl2l3XAlWBk9eMszqHi7Zj7d2-AZdFXWzEaq1waSDSGCqbGapEqfaO5ySgMpZ6HLp0zzso0GgrP8u27NtzOgG2SEMcgmv07gI5J-XmVCixyDl1WWShJ3lkdcp9MEfrWpVlme8JqrKnoaYwuuX6J83VJeFk0NRndemirSsOCFHy2YIOm2VUX4CHVTZ5Y3S0XnW508xScxrK9OLNjoLGbAvuMzW5zo~ewmNhl8NcFWLy7yLJPOfD2KbWv8obbfdNbBfOiaRj~PTrl-sWHF-2b9nzhgiPBaGzPteog__&Key-Pair-Id=K2XWKDWM065EGO",
+                "folder_tree": ""
+            }
         """.trimIndent()
     }
 }


### PR DESCRIPTION
- Updated the `TpstreamNetworkAsset` and `Asset` models to handle playlist data from the API response.
- If the API does not provide the size, the existing fallback method using bitrate and duration will be applied, although it may be less accurate.