### PR TITLE
fix: Codec Selection for L3 Devices in DownloadResolutionSelectionSheet

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -2,7 +2,6 @@ package com.tpstream.player.ui
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,13 +12,11 @@ import android.widget.Toast
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import com.google.common.collect.ImmutableList
 import com.tpstream.player.*
 import com.tpstream.player.R
 import com.tpstream.player.databinding.TpDownloadTrackSelectionDialogBinding
 import com.tpstream.player.data.Asset
 import com.tpstream.player.data.Track
-import com.tpstream.player.data.source.network.TPStreamsNetworkAsset
 import com.tpstream.player.offline.VideoDownloadRequestCreationHandler
 import com.tpstream.player.util.DeviceUtil
 import okio.IOException
@@ -183,13 +180,7 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
 
         // Function to get the codec based on resolution support
         fun selectBestCodec(codecs: List<DeviceUtil.CodecDetails>): DeviceUtil.CodecDetails? {
-            return codecs.maxByOrNull {
-                when {
-                    it.is4KSupported -> 2
-                    it.is1080pSupported -> 1
-                    else -> 0
-                }
-            }
+            return codecs.maxByOrNull { it.priority }
         }
 
         return if (isDrmProtected) {

--- a/player/src/main/java/com/tpstream/player/util/DeviceUtil.kt
+++ b/player/src/main/java/com/tpstream/player/util/DeviceUtil.kt
@@ -20,7 +20,14 @@ internal class DeviceUtil {
         val is4KAt2xSupported: Boolean = false,
         var isSelected: Boolean = false,
         val isSecure: Boolean = false
-    )
+    ) {
+        val priority: Int
+            get() = when {
+                is4KSupported -> 2
+                is1080pSupported -> 1
+                else -> 0
+            }
+    }
 
     companion object {
         val RESOLUTION_1080P = Resolution(1920, 1080)


### PR DESCRIPTION
- Previously, the codec selection logic for DRM-protected content on L3 devices was incorrect due to the unavailability of secure codecs.
- In this commit, we improve the codec selection logic to prioritize secure codecs for DRM content, but if none are available, it falls back to non-secure codecs. For non-DRM content, it directly chooses the best non-secure codec based on resolution support.