### PR TITLE
fix: Display custom message for Error code 4001

### DIFF
--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -49,6 +49,7 @@ internal fun PlaybackException.getErrorMessage(playerId: String): String {
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, see <a href='https://example.com/troubleshooting-4001'>HELP</a>.\n Player code: ${this.errorCode}. Player Id: $playerId"
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Player code: ${this.errorCode}. Player Id: $playerId"
     }
 }

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -49,7 +49,7 @@ internal fun PlaybackException.getErrorMessage(playerId: String): String {
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
-        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "An error occurred while playing the video. Try restarting your device or playing another video. More help: https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "<html><body><p>An error occurred while playing the video. Try restarting your device or playing another video. More help <a href='https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001'>click here</a>.<br> Player code: ${this.errorCode}. Player Id: $playerId</p></body></html>"
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Player code: ${this.errorCode}. Player Id: $playerId"
     }
 }

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -35,8 +35,8 @@ internal fun PlaybackException.toError(): PlaybackError {
 
 internal fun TPException.getErrorMessage(playerId: String): String {
     return when {
-        this.isNetworkError() -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, visit https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\n Player code: ${4001}. Player Id: $playerId"
-            this.response?.code == 404 -> "The video is not available. Please try another one.\n Error code: 5001. Player Id: $playerId"
+        this.isNetworkError() -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Error code: 5004. Player Id: $playerId"
+        this.response?.code == 404 -> "The video is not available. Please try another one.\n Error code: 5001. Player Id: $playerId"
         this.isUnauthenticated() -> "Sorry, you don't have permission to access this video. Please check your credentials and try again.\n Error code: 5002. Player Id: $playerId"
         this.isServerError() -> "We're sorry, but there's an issue on our server. Please try again later.\n Error code: 5005. Player Id: $playerId"
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Error code: 5100. Player Id: $playerId"
@@ -49,7 +49,7 @@ internal fun PlaybackException.getErrorMessage(playerId: String): String {
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
-        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, visit https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, visit https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\\n Player code: ${this.errorCode}. Player Id: $playerId"
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Player code: ${this.errorCode}. Player Id: $playerId"
     }
 }

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -49,7 +49,7 @@ internal fun PlaybackException.getErrorMessage(playerId: String): String {
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
-        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, visit https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "An error occurred while playing the video. Try restarting your device or playing another video. More help: https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\n Player code: ${this.errorCode}. Player Id: $playerId"
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Player code: ${this.errorCode}. Player Id: $playerId"
     }
 }

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -35,8 +35,8 @@ internal fun PlaybackException.toError(): PlaybackError {
 
 internal fun TPException.getErrorMessage(playerId: String): String {
     return when {
-        this.isNetworkError() -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Error code: 5004. Player Id: $playerId"
-        this.response?.code == 404 -> "The video is not available. Please try another one.\n Error code: 5001. Player Id: $playerId"
+        this.isNetworkError() -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, visit https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\n Player code: ${4001}. Player Id: $playerId"
+            this.response?.code == 404 -> "The video is not available. Please try another one.\n Error code: 5001. Player Id: $playerId"
         this.isUnauthenticated() -> "Sorry, you don't have permission to access this video. Please check your credentials and try again.\n Error code: 5002. Player Id: $playerId"
         this.isServerError() -> "We're sorry, but there's an issue on our server. Please try again later.\n Error code: 5005. Player Id: $playerId"
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Error code: 5100. Player Id: $playerId"
@@ -49,7 +49,7 @@ internal fun PlaybackException.getErrorMessage(playerId: String): String {
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
-        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, see <a href='https://example.com/troubleshooting-4001'>HELP</a>.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "There was an issue initializing the video decoder. Please try restarting your device or playing a different video. For more details, visit https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001.\n Player code: ${this.errorCode}. Player Id: $playerId"
         else -> "Oops! Something went wrong. Please contact support for assistance and provide details about the issue.\n Player code: ${this.errorCode}. Player Id: $playerId"
     }
 }

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -3,7 +3,6 @@ package com.tpstream.player.ui
 import android.app.Dialog
 import android.content.pm.ActivityInfo
 import android.media.MediaCodec
-import android.net.ConnectivityManager
 import android.os.Bundle
 import android.text.Html
 import android.util.Log

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -4,7 +4,6 @@ import android.app.Dialog
 import android.content.pm.ActivityInfo
 import android.media.MediaCodec
 import android.os.Bundle
-import android.text.Html
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -3,7 +3,9 @@ package com.tpstream.player.ui
 import android.app.Dialog
 import android.content.pm.ActivityInfo
 import android.media.MediaCodec
+import android.net.ConnectivityManager
 import android.os.Bundle
+import android.text.Html
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -395,7 +397,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private fun showErrorMessage(message: String) {
         if (!this@TpStreamPlayerFragment.isAdded) return
         viewBinding.errorMessage.visibility = View.VISIBLE
-        viewBinding.errorMessage.text = message
+        viewBinding.errorMessage.text = Html.fromHtml(message)
     }
 
     private val tpStreamPlayerImplCallBack = object :TpStreamPlayerImplCallBack{

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -396,7 +396,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private fun showErrorMessage(message: String) {
         if (!this@TpStreamPlayerFragment.isAdded) return
         viewBinding.errorMessage.visibility = View.VISIBLE
-        viewBinding.errorMessage.text = Html.fromHtml(message)
+        viewBinding.errorMessage.text = message
     }
 
     private val tpStreamPlayerImplCallBack = object :TpStreamPlayerImplCallBack{

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -3,12 +3,16 @@ package com.tpstream.player.ui
 import android.app.Dialog
 import android.content.pm.ActivityInfo
 import android.media.MediaCodec
+import android.os.Build
 import android.os.Bundle
+import android.text.Html
+import android.text.method.LinkMovementMethod
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageButton
+import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.tpstream.player.*
@@ -395,7 +399,24 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
     private fun showErrorMessage(message: String) {
         if (!this@TpStreamPlayerFragment.isAdded) return
         viewBinding.errorMessage.visibility = View.VISIBLE
-        viewBinding.errorMessage.text = message
+        if (isDecoderError(message)) {
+            viewBinding.errorMessage.setHtmlText(message)
+        } else {
+            viewBinding.errorMessage.text = message
+        }
+    }
+
+    private fun isDecoderError(message: String): Boolean {
+        return listOf("4001", "4003").any { message.contains(it) }
+    }
+
+    private fun TextView.setHtmlText(message: String) {
+        movementMethod = LinkMovementMethod.getInstance()
+        text = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            Html.fromHtml(message, Html.FROM_HTML_MODE_LEGACY)
+        } else {
+            Html.fromHtml(message)
+        }
     }
 
     private val tpStreamPlayerImplCallBack = object :TpStreamPlayerImplCallBack{

--- a/player/src/main/res/layout/fragment_tp_stream_player.xml
+++ b/player/src/main/res/layout/fragment_tp_stream_player.xml
@@ -19,6 +19,7 @@
             android:layout_gravity="center"
             android:textStyle="bold"
             android:visibility="gone"
+            android:padding="32dp"
             android:textAlignment="center"
             android:linksClickable="true"
             android:autoLink="web"

--- a/player/src/main/res/layout/fragment_tp_stream_player.xml
+++ b/player/src/main/res/layout/fragment_tp_stream_player.xml
@@ -20,6 +20,8 @@
             android:textStyle="bold"
             android:visibility="gone"
             android:textAlignment="center"
+            android:linksClickable="true"
+            android:autoLink="web"
             android:textSize="14dp"
             android:text=""/>
 

--- a/player/src/main/res/layout/fragment_tp_stream_player.xml
+++ b/player/src/main/res/layout/fragment_tp_stream_player.xml
@@ -21,8 +21,6 @@
             android:visibility="gone"
             android:padding="32dp"
             android:textAlignment="center"
-            android:linksClickable="true"
-            android:autoLink="web"
             android:textSize="14dp"
             android:text=""/>
 


### PR DESCRIPTION
- Previously, we displayed a generic error message for ExoPlayer error code 4001. This error typically occurs due to insufficient system resources, missing or incompatible decoder libraries, or similar issues. Restarting the device usually resolves it.
- We added a custom error message specifically for error code 4001.
- Included a troubleshooting link within the message for further assistance.