### PR TITLE
fix: Video shuttering issue while playing DRM content at 2x speed

### DIFF
--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -110,7 +110,7 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
                 }
             return renderersFactory.setMediaCodecSelector(softwareOnlyCodecSelector)
         }
-        return renderersFactory
+        return renderersFactory.forceEnableMediaCodecAsynchronousQueueing()
     }
 
     private fun getBandwidthMeter(): DefaultBandwidthMeter {

--- a/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
+++ b/player/src/main/java/com/tpstream/player/TpStreamPlayer.kt
@@ -90,7 +90,9 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
     }
 
     private fun getRenderersFactory(): DefaultRenderersFactory {
-        val renderersFactory = DefaultRenderersFactory(context).setEnableDecoderFallback(true)
+        val renderersFactory = DefaultRenderersFactory(context)
+            .setEnableDecoderFallback(true)
+            .forceEnableMediaCodecAsynchronousQueueing()
         if (useSoftwareDecoder) {
             val softwareOnlyCodecSelector =
                 MediaCodecSelector { mimeType, requiresSecureDecoder, requiresTunnelingDecoder ->
@@ -110,7 +112,7 @@ internal class TpStreamPlayerImpl(val context: Context) : TpStreamPlayer {
                 }
             return renderersFactory.setMediaCodecSelector(softwareOnlyCodecSelector)
         }
-        return renderersFactory.forceEnableMediaCodecAsynchronousQueueing()
+        return renderersFactory
     }
 
     private fun getBandwidthMeter(): DefaultBandwidthMeter {


### PR DESCRIPTION
- Enabled the ExoPlayer enhancement that adds additional threads for decoding video content on older devices. This option, which is enabled by default on Android 12 and above, ensures smoother playback of DRM-protected content at 2x speed. Enabling this feature prevents video stuttering and frame drops on devices with lower specifications.
- For more details, refer to [ExoPlayer issue #11209](https://github.com/google/ExoPlayer/issues/11209) and the [Android Media3 ExoPlayer customization guide](https://developer.android.com/media/media3/exoplayer/customization#enabling-asynchronous-buffer-queueing).