### PR TITLE
fix: Reset API call counters to prevent authentication loop

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -350,6 +350,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
 
         override fun onLicenseFetchSuccess(keySetId: ByteArray) {
             if (!this@TpStreamPlayerFragment.isAdded) return
+            offlineLicenseApiCallCount = 0
             OfflineDRMLicenseHelper.replaceKeysInExistingDownloadedVideo(
                 player.asset?.video?.url!!,
                 requireContext(),
@@ -451,6 +452,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         }
 
         override fun onPlayerPrepare() {
+            assetApiCallCount = 0
             if (player != null && startPosition != -1L) {
                 player.seekTo(startPosition)
                 player.pause()


### PR DESCRIPTION
- Resolved an issue where API call counters (`offlineLicenseApiCallCount` and `assetApiCallCount`) were not reset after a successful license fetch or player preparation.
- Previously, this caused an authentication failure loop even when a valid access token was provided after an initial failure. Now, the counters reset correctly, enabling proper reauthentication and playback reinitialization when the app is reopened or a new access token is passed.