### PR TITLE
fix: Mark functions exposing ExoPlayer objects as deprecated

### DIFF
--- a/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
+++ b/player/src/main/java/com/tpstream/player/TPStreamPlayerListener.kt
@@ -6,13 +6,17 @@ interface TPStreamPlayerListener {
     fun onTracksChanged(tracks: Tracks) {}
     fun onIsPlayingChanged(playing: Boolean) {}
     fun onIsLoadingChanged(loading: Boolean) {}
+    @Deprecated("Deprecated",level = DeprecationLevel.WARNING)
     fun onDeviceInfoChanged(deviceInfo: DeviceInfo) {}
     fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {}
     fun onEvents(player: TpStreamPlayer?, events: PlayerEvents) {}
     fun onSeekBackIncrementChanged(seekBackIncrementMs: Long) {}
     fun onSeekForwardIncrementChanged(seekForwardIncrementMs: Long) {}
+    @Deprecated("Deprecated",level = DeprecationLevel.WARNING)
     fun onVideoSizeChanged(videoSize: VideoSize) {}
+    @Deprecated("Deprecated",level = DeprecationLevel.WARNING)
     fun onPositionDiscontinuity(oldPosition: PlayerPositionInfo, newPosition: PlayerPositionInfo, reason: Int) {}
+    @Deprecated("Deprecated",level = DeprecationLevel.WARNING)
     fun onTimelineChanged(timeline: Timeline, reason: Int) {}
     fun onPlaybackStateChanged(playbackState: Int) {}
     fun onPlayerError(playbackError: PlaybackError) {}


### PR DESCRIPTION
- Added `@Deprecated` annotations to functions in `TPStreamPlayerListener` that expose `ExoPlayer` objects (`DeviceInfo`, `VideoSize`, `PlayerPositionInfo`, and `Timeline`).
- Since our SDK wraps ExoPlayer, directly exposing its objects can lead to build issues for users who may not have the correct ExoPlayer dependencies. Deprecating these functions ensures better compatibility and prevents unintended dependency issues.
- Moving forward, we should introduce alternative methods that abstract ExoPlayer-specific types to maintain SDK independence.