### PR TITLE
fix: Adjust bottom bar height to prevent ExoPlayer minimal mode

### DIFF
--- a/player/src/main/player-mapping-files/layout/exo_player2_control_view.xml
+++ b/player/src/main/player-mapping-files/layout/exo_player2_control_view.xml
@@ -27,7 +27,7 @@
 
     <FrameLayout android:id="@id/exo_bottom_bar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/exo_styled_bottom_bar_height"
+        android:layout_height="50dp"
         android:layout_marginTop="@dimen/exo_styled_bottom_bar_margin_top"
         android:layout_gravity="bottom"
         android:background="@color/exo_bottom_bar_background"
@@ -151,7 +151,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/exo_styled_progress_layout_height"
         android:layout_gravity="bottom"
-        android:layout_marginBottom="@dimen/exo_styled_progress_margin_bottom"/>
+        android:layout_marginBottom="42dp"/>
 
     <LinearLayout android:id="@id/exo_minimal_controls"
         android:layout_width="wrap_content"

--- a/player/src/main/player-mapping-files/layout/media3_player_control_view.xml
+++ b/player/src/main/player-mapping-files/layout/media3_player_control_view.xml
@@ -27,7 +27,7 @@
 
     <FrameLayout android:id="@id/exo_bottom_bar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/exo_styled_bottom_bar_height"
+        android:layout_height="50dp"
         android:layout_marginTop="@dimen/exo_styled_bottom_bar_margin_top"
         android:layout_gravity="bottom"
         android:background="@color/exo_bottom_bar_background"
@@ -153,7 +153,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/exo_styled_progress_layout_height"
         android:layout_gravity="bottom"
-        android:layout_marginBottom="@dimen/exo_styled_progress_margin_bottom"/>
+        android:layout_marginBottom="42dp"/>
 
     <LinearLayout android:id="@id/exo_minimal_controls"
         android:layout_width="wrap_content"

--- a/player/src/main/res/layout/exo_player_control_view.xml
+++ b/player/src/main/res/layout/exo_player_control_view.xml
@@ -27,7 +27,7 @@
 
     <FrameLayout android:id="@id/exo_bottom_bar"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/exo_styled_bottom_bar_height"
+        android:layout_height="50dp"
         android:layout_marginTop="@dimen/exo_styled_bottom_bar_margin_top"
         android:layout_gravity="bottom"
         android:background="@color/exo_bottom_bar_background"
@@ -153,7 +153,7 @@
         android:layout_width="match_parent"
         android:layout_height="@dimen/exo_styled_progress_layout_height"
         android:layout_gravity="bottom"
-        android:layout_marginBottom="@dimen/exo_styled_progress_margin_bottom"/>
+        android:layout_marginBottom="42dp"/>
 
     <LinearLayout android:id="@id/exo_minimal_controls"
         android:layout_width="wrap_content"


### PR DESCRIPTION
- When the user sets the screen size to large, all UI elements scale up, reducing available space in the player controls. This causes ExoPlayer to switch to minimal mode, hiding the next/previous track buttons.
- Since ExoPlayer currently doesn’t provide an option to control minimal mode externally, this update reduces the bottom bar height to `50dp` and the progress bar margin to `42dp`. This ensures that all controls remain visible even on large screen sizes.
- Once ExoPlayer allows explicit control over minimal mode, we will replace this workaround accordingly.