### PR TITLE
fix: Ensure consistent bottom sheet theme across all platforms

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/AdvancedResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/AdvancedResolutionSelectionSheet.kt
@@ -26,6 +26,10 @@ internal class AdvancedResolutionSelectionSheet(
     private var selectedCodecDetails: DeviceUtil.CodecDetails? = null
     private val maxResolution: Int? by lazy { player.getMaxResolution() }
 
+    override fun getTheme(): Int {
+        return R.style.CustomBottomSheetDialogTheme
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -37,6 +37,10 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
     private var onSubmitListener: OnSubmitListener? = null
     private var codec: List<DeviceUtil.CodecDetails> = emptyList()
 
+    override fun getTheme(): Int {
+        return R.style.CustomBottomSheetDialogTheme
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/player/src/main/java/com/tpstream/player/ui/SimpleResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/SimpleResolutionSelectionSheet.kt
@@ -30,6 +30,10 @@ internal class SimpleResolutionSelectionSheet(
         const val TAG = "ModalBottomSheet"
     }
 
+    override fun getTheme(): Int {
+        return R.style.CustomBottomSheetDialogTheme
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/player/src/main/res/values-night/styles.xml
+++ b/player/src/main/res/values-night/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="CustomBottomSheetDialogTheme" parent="Theme.Design.BottomSheetDialog"/>
+
+</resources>

--- a/player/src/main/res/values/styles.xml
+++ b/player/src/main/res/values/styles.xml
@@ -17,4 +17,6 @@
         <item name="android:padding">0dp</item>
     </style>
 
+    <style name="CustomBottomSheetDialogTheme" parent="Theme.Design.Light.BottomSheetDialog"/>
+
 </resources>


### PR DESCRIPTION
- When using the Android player SDK in Flutter and React Native via native bindings, the bottom sheet theme was sometimes overridden by the host app’s theme. This caused UI inconsistencies, especially in dark mode, where text became unreadable.
- To resolve this, all bottom sheets (`AdvancedResolutionSelectionSheet`, `DownloadResolutionSelectionSheet`, and `SimpleResolutionSelectionSheet`) now explicitly use `CustomBottomSheetDialogTheme`. This ensures a consistent appearance across all platforms, preventing theme conflicts in different integrations.