### PR TITLE
fix: Properly detach player when releasing

### DIFF
--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -180,7 +180,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
 
     fun setPlayer(player: TpStreamPlayer) {
         this.player = player as TpStreamPlayerImpl
-        playerView.player = null
+        playerView.player = null // Detach any existing player first
         playerView.player = this.player.exoPlayer
         player.exoPlayer.addAnalyticsListener(PlayerViewAnalyticsListener(this))
         initializeLoadCompleteListener()

--- a/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TPStreamPlayerView.kt
@@ -180,6 +180,7 @@ class TPStreamPlayerView @JvmOverloads constructor(
 
     fun setPlayer(player: TpStreamPlayer) {
         this.player = player as TpStreamPlayerImpl
+        playerView.player = null
         playerView.player = this.player.exoPlayer
         player.exoPlayer.addAnalyticsListener(PlayerViewAnalyticsListener(this))
         initializeLoadCompleteListener()

--- a/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
+++ b/player/src/main/java/com/tpstream/player/ui/TpStreamPlayerFragment.kt
@@ -91,7 +91,7 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         super.onPause()
         if (Util.SDK_INT <= 23) {
             storeCurrentPlayTime()
-            player?.release()
+            releasePlayer()
         }
         Log.d(TAG, "onPause: ")
     }
@@ -100,9 +100,14 @@ class TpStreamPlayerFragment : Fragment(), DownloadCallback.Listener {
         super.onStop()
         if (Util.SDK_INT > 23) {
             storeCurrentPlayTime()
-            player?.release()
+            releasePlayer()
         }
         Log.d(TAG, "onStop: ")
+    }
+
+    private fun releasePlayer() {
+        player?.release()
+        tpStreamPlayerView.playerView.player = null
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
- Previously, when releasing the player in onPause or onStop, playerView.player was not explicitly set to null. As a result, when the app resumed, a new player instance was created and assigned to playerView, but the old reference remained. This occasionally led to unpredictable behavior, including random 4003 errors.
- This fix ensures that playerView.player is set to null before assigning a new player instance, preventing conflicts and ensuring a clean player reinitialization process.