### PR TITLE
fix: DRM license fetching before resolution selection

### DIFF
--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -108,11 +108,8 @@ internal class VideoDownloadRequestCreationHandler(
 
     override fun onLicenseFetchSuccess(keySetId: ByteArray) {
         val name = asset.title
-        onDownloadRequestCreated?.let { it(downloadHelper.getDownloadRequest(Util.getUtf8Bytes(name)).copyWithKeySetId(keySetId)) }
-        CoroutineScope(Dispatchers.Main).launch {
-            Log.d("TAG", "onLicenseFetchSuccess: Success")
-            listener?.onDownloadRequestHandlerPrepared(true, downloadHelper)
-        }
+        val downloadHelper = downloadHelper.getDownloadRequest(Util.getUtf8Bytes(name)).copyWithKeySetId(keySetId)
+        onDownloadRequestCreated?.invoke(downloadHelper)
     }
 
     override fun onLicenseFetchFailure(error: DrmSessionException) {

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -130,9 +130,9 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
     private fun setOnClickListeners() {
         binding.startDownload.setOnClickListener {
             if (isResolutionSelected){
-                val downloadRequest =
-                    videoDownloadRequestCreateHandler.buildDownloadRequest(overrides)
-                onSubmitListener?.invoke(downloadRequest,asset)
+                videoDownloadRequestCreateHandler.buildDownloadRequest(overrides) { downloadRequest ->
+                    onSubmitListener?.invoke(downloadRequest,asset)
+                }
                 Toast.makeText(requireContext(), "Download Start", Toast.LENGTH_SHORT).show()
                 dismiss()
             } else {


### PR DESCRIPTION
- Previously, the DRM license was fetched before displaying the download resolution selection sheet. This caused an issue for users with single-expiry access tokens, as they needed to provide a new token each time they opened the sheet.
- The DRM license is now fetched only after the user selects a resolution and clicks "Download," reducing unnecessary license fetches.
- The bottom sheet no longer shows a loading state while fetching the DRM license, reducing wait time.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Upgraded the download process to work asynchronously, ensuring a more responsive experience.
  - Enhanced error notifications during download setup for smoother user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->