### PR TITLE
fix: Unable to download the DRM video with single accessToken

### DIFF
--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -45,7 +45,6 @@ class PlayerActivity : AppCompatActivity() {
 
                     override fun onAccessTokenExpired(videoId: String, callback: (String) -> Unit) {
                         val newAccessToken = getAccessToken(videoId)
-                        Log.d("TAG", "onAccessTokenExpired: ")
                         callback.invoke(newAccessToken)
                     }
 
@@ -103,8 +102,8 @@ class PlayerActivity : AppCompatActivity() {
                 provider = TPStreamsSDK.Provider.TestPress
             }
             "TPS_DRM" -> {
-                accessToken = "f8f5ebf2-c4ed-45d1-b7ae-6fffae64b0bc"
-                videoId = "AgAFNEJn3kt"
+                accessToken = "d4986429-20e2-4b21-93ae-c70630a37e06"
+                videoId = "7RKQZj4gB2T"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
@@ -136,7 +135,7 @@ class PlayerActivity : AppCompatActivity() {
             "ZZb3S5OB3nY" -> "5f6355d0-62ac-4bfd-98ca-4a1e9a2857e3"
             "z1TLpfuZzXh" -> "5c49285b-0557-4cef-b214-66034d0b77c3"
             "6suEBPy7EG4" -> "ab70caed-6168-497f-89c1-1e308da2c9aa"
-            "AgAFNEJn3kt" -> "3289c956-c773-48ad-a6ab-dba9b05053c0"
+            "C65BJzhj48k" -> "48a481d0-7a7f-465f-9d18-86f52129430b"
             else -> ""
         }
     }

--- a/app/src/main/java/com/tpstream/app/PlayerActivity.kt
+++ b/app/src/main/java/com/tpstream/app/PlayerActivity.kt
@@ -45,6 +45,7 @@ class PlayerActivity : AppCompatActivity() {
 
                     override fun onAccessTokenExpired(videoId: String, callback: (String) -> Unit) {
                         val newAccessToken = getAccessToken(videoId)
+                        Log.d("TAG", "onAccessTokenExpired: ")
                         callback.invoke(newAccessToken)
                     }
 
@@ -102,8 +103,8 @@ class PlayerActivity : AppCompatActivity() {
                 provider = TPStreamsSDK.Provider.TestPress
             }
             "TPS_DRM" -> {
-                accessToken = "d4986429-20e2-4b21-93ae-c70630a37e06"
-                videoId = "7RKQZj4gB2T"
+                accessToken = "f8f5ebf2-c4ed-45d1-b7ae-6fffae64b0bc"
+                videoId = "AgAFNEJn3kt"
                 orgCode = "6eafqn"
                 provider = TPStreamsSDK.Provider.TPStreams
             }
@@ -135,7 +136,7 @@ class PlayerActivity : AppCompatActivity() {
             "ZZb3S5OB3nY" -> "5f6355d0-62ac-4bfd-98ca-4a1e9a2857e3"
             "z1TLpfuZzXh" -> "5c49285b-0557-4cef-b214-66034d0b77c3"
             "6suEBPy7EG4" -> "ab70caed-6168-497f-89c1-1e308da2c9aa"
-            "C65BJzhj48k" -> "48a481d0-7a7f-465f-9d18-86f52129430b"
+            "AgAFNEJn3kt" -> "3289c956-c773-48ad-a6ab-dba9b05053c0"
             else -> ""
         }
     }

--- a/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
+++ b/player/src/main/java/com/tpstream/player/offline/OfflineDRMLicenseHelper.kt
@@ -1,6 +1,7 @@
 package com.tpstream.player.offline
 
 import android.content.Context
+import android.media.MediaCodec
 import android.net.ConnectivityManager
 import android.net.NetworkInfo
 import android.net.Uri
@@ -11,6 +12,7 @@ import com.tpstream.player.util.CustomHttpDrmMediaCallback
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import java.io.IOException
 import java.lang.Long.min
 
 internal object OfflineDRMLicenseHelper {
@@ -133,6 +135,14 @@ internal object OfflineDRMLicenseHelper {
                 offlineLicenseHelper.release()
             }
         }
+    }
+
+    fun isDRMAuthenticationError(exception: IOException): Boolean {
+        val cause = exception.cause
+        return (cause is DrmSessionException ||
+                cause is MediaCodec.CryptoException ||
+                cause is MediaDrmCallbackException) &&
+                exception.localizedMessage?.contains("401") == true
     }
 }
 

--- a/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
+++ b/player/src/main/java/com/tpstream/player/offline/TpStreamDownloadManager.kt
@@ -100,11 +100,12 @@ class TpStreamDownloadManager(val context: Context) {
         }
         downloadResolutionSelectionSheet._setOnAccessTokenExpiredListener(object : OnAccessTokenExpiredListener{
             override fun onExpired() {
-                player?._listener?.onAccessTokenExpired(params.videoId!!) {
-                    downloadResolutionSelectionSheet.onAccessTokenExpire(it)
+                params.videoId?.let { videoId ->
+                    player?._listener?.onAccessTokenExpired(videoId) {
+                        downloadResolutionSelectionSheet.onAccessTokenExpire(it)
+                    }
                 }
             }
-
         })
     }
 

--- a/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
+++ b/player/src/main/java/com/tpstream/player/offline/VideoDownloadRequestCreationHandler.kt
@@ -19,21 +19,16 @@ internal class VideoDownloadRequestCreationHandler(
     private val params: TpInitParams
 ) :
     DownloadHelperCallback, DRMLicenseFetchCallback {
-    private var downloadHelper: DownloadHelper
-    private val trackSelectionParameters: DefaultTrackSelectorParameters = DownloadHelper.getDefaultTrackSelectorParameters(context)
+    private val downloadHelper: DownloadHelper
+    private val trackSelectionParameters: DefaultTrackSelectorParameters
     var listener: Listener? = null
-    private lateinit var mediaItem: MediaItem
+    private val mediaItem: MediaItem
     private var onDownloadRequestCreated: onDownloadRequestCreated? = null
     private var offlineDRMLicenseApiCallCount = 0
 
     init {
-        buildMediaItem()
-        downloadHelper = getDownloadHelper()
-        downloadHelper.prepare(this)
-    }
-
-    private fun buildMediaItem() {
         val url = asset.video.url
+        trackSelectionParameters = DownloadHelper.getDefaultTrackSelectorParameters(context)
         val drmLicenseURL = TPStreamsSDK.constructOfflineDRMLicenseUrl(params.videoId, params.accessToken, params.licenseDurationSeconds)
         mediaItem = MediaItemBuilder()
             .setUri(url)
@@ -44,6 +39,8 @@ internal class VideoDownloadRequestCreationHandler(
                     .build()
             )
             .build()
+        downloadHelper = getDownloadHelper()
+        downloadHelper.prepare(this)
     }
 
     fun fetchNewDRMLicence(accessToken: String){

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -2,6 +2,7 @@ package com.tpstream.player.ui
 
 import android.content.Context
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -77,7 +78,13 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
     }
 
     override fun onDownloadRequestHandlerPrepareError(downloadHelper: DownloadHelper, e: IOException) {
-        dismiss()
+        Log.d("TAG", "onDownloadRequestHandlerPrepareError: ${e.localizedMessage}")
+
+        if (e.localizedMessage.contains("401")){
+            onAccessTokenExpiredListener?.onExpired()
+        } else {
+            dismiss()
+        }
     }
 
     private fun prepareTrackGroup(helper: DownloadHelper){
@@ -308,4 +315,18 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
         onSubmitListener = listener
     }
 
+    var onAccessTokenExpiredListener: OnAccessTokenExpiredListener? = null
+
+    fun _setOnAccessTokenExpiredListener(listener: OnAccessTokenExpiredListener){
+        onAccessTokenExpiredListener = listener
+    }
+
+    fun onAccessTokenExpire(newAccessToken: String){
+        videoDownloadRequestCreateHandler.fetchNewDRMLicence(newAccessToken)
+    }
+
+}
+
+interface OnAccessTokenExpiredListener {
+    fun onExpired()
 }

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -2,7 +2,6 @@ package com.tpstream.player.ui
 
 import android.content.Context
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup

--- a/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
+++ b/player/src/main/java/com/tpstream/player/ui/DownloadResolutionSelectionSheet.kt
@@ -18,6 +18,7 @@ import com.tpstream.player.R
 import com.tpstream.player.databinding.TpDownloadTrackSelectionDialogBinding
 import com.tpstream.player.data.Asset
 import com.tpstream.player.data.Track
+import com.tpstream.player.offline.OfflineDRMLicenseHelper
 import com.tpstream.player.offline.VideoDownloadRequestCreationHandler
 import com.tpstream.player.util.DeviceUtil
 import okio.IOException
@@ -78,9 +79,7 @@ internal class DownloadResolutionSelectionSheet : BottomSheetDialogFragment(), V
     }
 
     override fun onDownloadRequestHandlerPrepareError(downloadHelper: DownloadHelper, e: IOException) {
-        Log.d("TAG", "onDownloadRequestHandlerPrepareError: ${e.localizedMessage}")
-
-        if (e.localizedMessage.contains("401")){
+        if (OfflineDRMLicenseHelper.isDRMAuthenticationError(e)){
             onAccessTokenExpiredListener?.onExpired()
         } else {
             dismiss()


### PR DESCRIPTION
- Added a callback mechanism (OnAccessTokenExpiredListener) to request a new access token when the DRM license fetch fails with a 401 error.
- Updated OfflineDRMLicenseHelper to detect DRM authentication errors.
- Integrated token refresh handling in TpStreamDownloadManager and DownloadResolutionSelectionSheet.
- Implemented retry logic in VideoDownloadRequestCreationHandler, allowing up to 3 retries with a new token before failing.
- If all retries fail, the user sees an error message indicating that the video download cannot proceed due to a license issue.