### PR TITLE
chore: Update GitHub Actions to use JDK 17

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - name: set up JDK 11
-        uses: actions/setup-java@v1
+      - uses: actions/checkout@v3
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
         with:
-          java-version: 11
+          java-version: 17
 
       - name: Run Test
         run: ./gradlew test

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -8,10 +8,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: set up JDK 17
+
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: 17
+          distribution: temurin
+          cache: gradle
 
       - name: Run Test
         run: ./gradlew test


### PR DESCRIPTION
- Updated GitHub Actions workflow to use JDK 17.
- Ensures compatibility with AGP 8+ and modern Gradle builds.