### PR TITLE
build: Upgrade build toolchain for AGP 8.5.2 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.3.1' apply false
-    id 'com.android.library' version '7.3.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.10' apply false
+    id 'com.android.application' version '8.5.2' apply false
+    id 'com.android.library' version '8.5.2' apply false
+    id 'org.jetbrains.kotlin.android' version '1.9.25' apply false
     id "io.sentry.android.gradle" version "3.1.6"
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 02 16:10:16 IST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/player/build.gradle
+++ b/player/build.gradle
@@ -40,14 +40,15 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '17'
     }
 
     buildFeatures {
+        buildConfig true
         viewBinding true
     }
 
@@ -60,7 +61,7 @@ android {
 
 def media3playerVersion = "1.1.1"
 def exoPlayer2Version = "2.19.1"
-def room_version = "2.5.2"
+def room_version = "2.6.1"
 
 dependencies {
 


### PR DESCRIPTION
- Upgraded Gradle Wrapper from 7.4 to 8.7. 
- Upgraded Android Gradle Plugin from 7.3.1 to 8.5.2. 
- Upgraded Kotlin Android Plugin from 1.7.10 to 1.9.25. 
- Upgraded Room version from 2.5.2 to 2.6.1.