### PR TITLE
chore: Update Sentry Android SDK to version 7.20.0

### DIFF
--- a/player/build.gradle
+++ b/player/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
     api "androidx.room:room-ktx:$room_version"
     api 'androidx.fragment:fragment-ktx:1.5.4'
-    api 'io.sentry:sentry-android:6.4.2'
+    api 'io.sentry:sentry-android:7.20.0'
     if (useMedia3Library) {
         api "androidx.media3:media3-exoplayer:$media3playerVersion"
         api "androidx.media3:media3-ui:$media3playerVersion"


### PR DESCRIPTION
- Upgraded Sentry Android SDK from 6.4.2 → 7.20.0
- The older Sentry version packaged native `.so` binaries aligned to 4KB pages.
- Google Play now requires all apps to support devices with 16KB page sizes.
- The new Sentry release includes updated native libraries aligned to 16KB,
  ensuring compatibility with upcoming Android devices and Play Store policies.