### PR TITLE
feat: Show accurate error for slow or unstable network conditions

### DIFF
--- a/player/src/main/java/com/tpstream/player/TPException.kt
+++ b/player/src/main/java/com/tpstream/player/TPException.kt
@@ -39,6 +39,19 @@ data class TPException(
 
     fun isNetworkError() = errorType == ErrorType.NETWORK
 
+    fun isTimeoutError(): Boolean {
+        var current: Throwable? = exception
+        while (current != null) {
+            if (current is java.net.SocketTimeoutException ||
+                current is java.io.InterruptedIOException ||
+                current is java.util.concurrent.TimeoutException) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+
     fun isUnauthenticated() = statusCode == 401
 
     fun isClientError() = statusCode in 400..499 && statusCode != 401

--- a/player/src/main/java/com/tpstream/player/TPException.kt
+++ b/player/src/main/java/com/tpstream/player/TPException.kt
@@ -2,6 +2,7 @@ package com.tpstream.player
 
 import okhttp3.Response
 import java.io.IOException
+import com.tpstream.player.constants.isTimeoutCause
 
 data class TPException(
     val errorMessage: String?,
@@ -39,18 +40,7 @@ data class TPException(
 
     fun isNetworkError() = errorType == ErrorType.NETWORK
 
-    fun isTimeoutError(): Boolean {
-        var current: Throwable? = exception
-        while (current != null) {
-            if (current is java.net.SocketTimeoutException ||
-                current is java.io.InterruptedIOException ||
-                current is java.util.concurrent.TimeoutException) {
-                return true
-            }
-            current = current.cause
-        }
-        return false
-    }
+    fun isTimeoutError(): Boolean = exception.isTimeoutCause()
 
     fun isUnauthenticated() = statusCode == 401
 

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -23,7 +23,7 @@ internal fun TPException.toError(): PlaybackError {
     }
 }
 
-private fun Throwable?.isTimeoutCause(): Boolean {
+internal fun Throwable?.isTimeoutCause(): Boolean {
     var current: Throwable? = this
     while (current != null) {
         if (current is java.net.SocketTimeoutException ||
@@ -59,10 +59,9 @@ internal fun TPException.getErrorMessage(playerId: String): String {
 
 internal fun PlaybackException.getErrorMessage(playerId: String): String {
     return when (this.errorCode) {
-        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> {
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED ->
             if (this.cause.isTimeoutCause()) "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
             else "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
-        }
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "<html><body><p>An error occurred while playing the video. Try restarting your device or playing another video. More help <a href='https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001'>click here</a>.<br> Player code: ${this.errorCode}. Player Id: $playerId</p></body></html>"

--- a/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
+++ b/player/src/main/java/com/tpstream/player/constants/PlaybackError.kt
@@ -23,6 +23,18 @@ internal fun TPException.toError(): PlaybackError {
     }
 }
 
+private fun Throwable?.isTimeoutCause(): Boolean {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is java.net.SocketTimeoutException ||
+            current is java.io.InterruptedIOException ||
+            current is java.util.concurrent.TimeoutException) {
+            return true
+        }
+        current = current.cause
+    }
+    return false
+}
 
 internal fun PlaybackException.toError(): PlaybackError {
     return when (this.errorCode) {
@@ -35,6 +47,7 @@ internal fun PlaybackException.toError(): PlaybackError {
 
 internal fun TPException.getErrorMessage(playerId: String): String {
     return when {
+        this.isTimeoutError() -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Error code: 5004. Player Id: $playerId"
         this.isNetworkError() -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Error code: 5004. Player Id: $playerId"
         this.response?.code == 404 -> "The video is not available. Please try another one.\n Error code: 5001. Player Id: $playerId"
         this.isUnauthenticated() -> "Sorry, you don't have permission to access this video. Please check your credentials and try again.\n Error code: 5002. Player Id: $playerId"
@@ -46,7 +59,10 @@ internal fun TPException.getErrorMessage(playerId: String): String {
 
 internal fun PlaybackException.getErrorMessage(playerId: String): String {
     return when (this.errorCode) {
-        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED -> {
+            if (this.cause.isTimeoutCause()) "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
+            else "Oops! It seems like you're not connected to the internet. Please check your connection and try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
+        }
         PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT -> "The request took too long to process due to a slow or unstable network connection. Please try again.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DRM_LICENSE_ACQUISITION_FAILED -> "There was an issue fetching the license key for this video. Please try again later.\n Player code: ${this.errorCode}. Player Id: $playerId"
         PlaybackException.ERROR_CODE_DECODER_INIT_FAILED -> "<html><body><p>An error occurred while playing the video. Try restarting your device or playing another video. More help <a href='https://tpstreams.com/help/troubleshooting-steps-for-error-code-4001'>click here</a>.<br> Player code: ${this.errorCode}. Player Id: $playerId</p></body></html>"
@@ -57,6 +73,7 @@ internal fun PlaybackException.getErrorMessage(playerId: String): String {
 
 internal fun TPException.getErrorMessageForDownload(): String {
     return when {
+        this.isTimeoutError() -> "The download took too long to process due to a slow or unstable network connection. Please try again."
         this.isNetworkError() -> "Please check your connection and try again"
         this.response?.code == 404 -> "The video is not available. Please try another one."
         this.isUnauthenticated() -> "Sorry, you don't have permission to download this video"


### PR DESCRIPTION
- Users were shown a generic "no internet" error even when the connection was slow or unstable
- This occurred because timeout scenarios were not differentiated from complete network failures
- Now detects timeout-specific cases and surfaces a clear "slow or unstable network connection" message while preserving the existing error structure to avoid unnecessary changes