### PR TITLE
fix: include userId and videoId in Sentry exception logs

### DIFF
--- a/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
+++ b/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
@@ -4,6 +4,7 @@ import com.tpstream.player.*
 import com.tpstream.player.BuildConfig.TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME
 import com.tpstream.player.PlaybackException
 import io.sentry.Sentry
+import io.sentry.protocol.User
 
 internal object SentryLogger {
 
@@ -26,6 +27,7 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
+            scope.setTag("videoId", params?.videoId ?: "")
             scope.setContexts(
                 "TPStreamsSDK",
                 mapOf(
@@ -57,6 +59,7 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
+            scope.setTag("videoId", params?.videoId ?: "")
             scope.setContexts(
                 "TPStreamsSDK",
                 mapOf(
@@ -87,6 +90,7 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
+            scope.setTag("videoId", params?.videoId ?: "")
             scope.setContexts(
                 "TPStreamsSDK",
                 mapOf(

--- a/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
+++ b/player/src/main/java/com/tpstream/player/util/SentryLogger.kt
@@ -4,7 +4,6 @@ import com.tpstream.player.*
 import com.tpstream.player.BuildConfig.TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME
 import com.tpstream.player.PlaybackException
 import io.sentry.Sentry
-import io.sentry.protocol.User
 
 internal object SentryLogger {
 
@@ -27,7 +26,7 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
-            scope.setTag("videoId", params?.videoId ?: "")
+            params?.videoId?.let { scope.setTag("videoId", it) }
             scope.setContexts(
                 "TPStreamsSDK",
                 mapOf(
@@ -59,7 +58,7 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
-            scope.setTag("videoId", params?.videoId ?: "")
+            params?.videoId?.let { scope.setTag("videoId", it) }
             scope.setContexts(
                 "TPStreamsSDK",
                 mapOf(
@@ -90,7 +89,7 @@ internal object SentryLogger {
             scope.setTag("TPStreamsAndroidPlayerSDKVersion",TPSTREAMS_ANDROID_PALYER_SDK_VERSION_NAME)
             scope.setTag("playerId", playerId)
             scope.setTag("userId", params?.userId ?: "")
-            scope.setTag("videoId", params?.videoId ?: "")
+            params?.videoId?.let { scope.setTag("videoId", it) }
             scope.setContexts(
                 "TPStreamsSDK",
                 mapOf(


### PR DESCRIPTION
* Added `videoId` as a Sentry tag alongside `userId` and `playerId`
* Applied consistently across API, playback, and DRM exception logging
* Improves tracing issues to a specific video context
